### PR TITLE
fix group dms not working sometimes

### DIFF
--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -348,7 +348,7 @@ let userDataFunction = async user => {
         var i = e.length - t.length;
         return i || (e > t ? i = 1 : e < t && (i = -1)), i;
     };
-    function renderConversation(convo, convoId, newMessages = true, updateConvo = true) {
+    async function renderConversation(convo, convoId, newMessages = true, updateConvo = true) {
         if(updateConvo) {
             lastConvo = convo;
             lastConvo.conversation_id = convoId;
@@ -381,6 +381,20 @@ let userDataFunction = async user => {
         if(!lastConvo.entries) {
             modal.getElementsByClassName('messages-load-more')[0].hidden = true;
             return;
+        }
+        let missingUserIds = [];
+        for(let j in lastConvo.entries) {
+            let m = lastConvo.entries[j].message;
+            if(!m) continue;
+            if(!lastConvo.users[m.message_data.sender_id] && !missingUserIds.includes(m.message_data.sender_id)) {
+                missingUserIds.push(m.message_data.sender_id);
+            }
+        }
+        if(missingUserIds.length > 0) {
+            let foundUsers = await API.lookupUsers(missingUserIds)
+            foundUsers.forEach(user => {
+                lastConvo.users[user.id_str] = user;
+            });
         }
         lastConvo.entries = lastConvo.entries.reverse();
         let messageElements = [];


### PR DESCRIPTION
(this is my first pull request ever so sorry for like, anything?)

group dms sometimes wouldn't load

the reason this happened is because API.getConversation only returned users that had messaged recently, and not ones that reacted recently because oldtwitter doesnt send the "support_reactions=1" query parameter in the conversation api (if it did, then reactions wouldnt show up whatsoever, since they are regularly unsupported in oldtwitter)

so, to fix it, i made it so that every time you open a dm, it checks if there are any missing users, then it adds them to a list of missing users, and then uses API.lookupUsers to all of the missing users' info (in batch of course, not each user separately), then renders conversation as normal