### PR TITLE
fix mentions at the start of tweets not appearing

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1278,7 +1278,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
             }
         }
         let full_text = t.full_text ? t.full_text : '';
-        if(location.pathname.includes('/status/')) full_text = full_text.replace(/^((?<!\w)@([\w+]{1,15})\s)+/, '')
+        if(location.pathname.includes('/status/')) full_text = full_text.substring(t.display_text_range[0], t.display_text_range[1]);
         let textWithoutLinks = full_text.replace(/(?:https?|ftp):\/\/[\n\S]+/g, '').replace(/(?<!\w)@([\w+]{1,15}\b)/g, '');
         let isEnglish
         try { 

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1278,7 +1278,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
             }
         }
         let full_text = t.full_text ? t.full_text : '';
-        if(location.pathname.includes('/status/')) full_text = full_text.substring(t.display_text_range[0], t.display_text_range[1]);
+        if(location.pathname.includes('/status/')) full_text = Array.from(full_text).slice(t.display_text_range[0], t.display_text_range[1]).join(''); //Array.from helps with parsing emojis correctly, otherwise this may cut off 2 byte emojis
         let textWithoutLinks = full_text.replace(/(?:https?|ftp):\/\/[\n\S]+/g, '').replace(/(?<!\w)@([\w+]{1,15}\b)/g, '');
         let isEnglish
         try { 

--- a/scripts/tweetviewer.js
+++ b/scripts/tweetviewer.js
@@ -785,7 +785,7 @@ class TweetViewer {
             }
         }
         let full_text = t.full_text ? t.full_text : '';
-        full_text = full_text.replace(/^((?<!\w)@([\w+]{1,15})\s)+/, '')
+        full_text = full_text.substring(t.display_text_range[0], t.display_text_range[1]);
         let textWithoutLinks = full_text.replace(/(?:https?|ftp):\/\/[\n\S]+/g, '').replace(/(?<!\w)@([\w+]{1,15}\b)/g, '');
         let isEnglish
         try { 

--- a/scripts/tweetviewer.js
+++ b/scripts/tweetviewer.js
@@ -785,7 +785,7 @@ class TweetViewer {
             }
         }
         let full_text = t.full_text ? t.full_text : '';
-        full_text = full_text.substring(t.display_text_range[0], t.display_text_range[1]);
+        full_text = Array.from(full_text).slice(t.display_text_range[0], t.display_text_range[1]).join(''); //Array.from helps with parsing emojis correctly, otherwise this may cut off 2 byte emojis
         let textWithoutLinks = full_text.replace(/(?:https?|ftp):\/\/[\n\S]+/g, '').replace(/(?<!\w)@([\w+]{1,15}\b)/g, '');
         let isEnglish
         try { 


### PR DESCRIPTION
this is a fix for #146

when you would open a tweet/reply/quote (/status/* pages), if the user had put mentions at the beginning of the tweet, they would be cut off by oldtwitter (to fix the issue of replies showing the users they are replying to at the beginning of the text, which is presumably there for older clients)

to fix this, i split the tweet text with Array.from() (.split splits emojis by bytes, so that breaks things), then slice it using the tweet.display_text_range array that the api sends (this is what i think normal twitter clients do?), then join it back to a string, and that cuts off those fake mentions (since thats what tweet.display_text_range is partly for)