### PR TITLE
fix emojis breaking profile links in notifications

### DIFF
--- a/layouts/notifications/script.js
+++ b/layouts/notifications/script.js
@@ -131,16 +131,17 @@ async function renderNotifications(data, append = false) {
                     n.message.entities.forEach(e => {
                         if(!e.ref || !e.ref.user) return;
                         let user = data.globalObjects.users[e.ref.user.id];
-                        let emojiHelpers = matchEmojiHelperCount(notificationHeader);
-                        notificationHeader = stringInsert(notificationHeader, additionalLength+e.toIndex+emojiHelpers, '</a>');
-                        notificationHeader = stringInsert(notificationHeader, additionalLength+e.fromIndex, `<a href="/dimdenEFF">`);
+                        notificationHeader = Array.from(notificationHeader);
+                        notificationHeader = arrayInsert(notificationHeader, e.toIndex+additionalLength, '</a>');
+                        notificationHeader = arrayInsert(notificationHeader, e.fromIndex+additionalLength, `<a href="/dimdenEFF">`);
+                        notificationHeader = notificationHeader.join('');
                         additionalLength += `<a href="/dimdenEFF"></a>`.length;
                         let mi = 0;
                         let newText = notificationHeader.replace(aRegex, (_, m) => {
                             if(mi++ !== matches) return _;
                             return `<a href="/${user.screen_name}"${user.verified ? 'class="user-verified"' : ''}>${escapeHTML(m)}</a>`;
                         });
-                        additionalLength += newText.length - notificationHeader.length + emojiHelpers;
+                        additionalLength += newText.length - notificationHeader.length;
                         notificationHeader = newText;
                         matches++;
                     });

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -388,8 +388,8 @@ function escapeHTML(unsafe) {
          .replace(/"/g, "&quot;")
          .replace(/'/g, "’");
  }
-function stringInsert(string, index, value) {
-    return string.substr(0, index) + value + string.substr(index);
+function arrayInsert(arr, index, value) {
+    return [...arr.slice(0, index), value, ...arr.slice(index)];
 }
 function generatePoll(tweet, tweetElement, user) {
     let pollElement = tweetElement.getElementsByClassName('tweet-card')[0];
@@ -637,14 +637,6 @@ function generateCard(tweet, tweetElement, user) {
         generatePoll(tweet, tweetElement, user);
     }
 }
-let emojiCombination = /(\u00a9|\u00ae|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]{1,2}\u200D(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]{1,2}\u200D{0,1})+)/g;
-function matchEmojiHelperCount(str) {
-    let matches = str.matchAll(emojiCombination);
-    let count = 0;
-    for(let m of matches) count += m[2] ? m[2].length : 0;
-    return count;
-}
-
 function createEmojiPicker(container, input, style = {}) {
     let picker = new EmojiPicker({
         i18n: {


### PR DESCRIPTION
this is a fix for #33

when you would have a notification from someone with an emoji (particularly flag emojis and another modifiers), the link would be placed incorrectly, depending on how many emojis and what kind of emojis

to fix it, i split the notification header with Array.from() (again, .split() splits strings by bytes, Array.from() splits by characters i think), then insert the anchor tag wherever its supposed to go, then join it back to a string

i tested it with a test account and a case very similar to the one in the original issue, and it fixes the problem, and causes no other issues