### PR TITLE
fix(?) group dms not having icons and names

### DIFF
--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -583,7 +583,7 @@ let userDataFunction = async user => {
                     <span class="inbox-screenname">${messageUsers.length === 1 ? "@"+messageUsers[0].screen_name : ''}</span>
                     <span class="inbox-time">${timeElapsed(new Date(+lastMessage.time))}</span>
                     <br>
-                    <span class="inbox-message-preview">${lastMessage.reason ? 'Accepted conversation' : lastMessage.message_data.text === 'dmservice_reaction_one_to_one_text' ? `${lastMessage.message_data.sender_id === user.id_str ? 'You reacted to message' : `${escapeHTML(messageUsers[0].name)} reacted to message`}` : escapeHTML(lastMessage.message_data.text)}</span>
+                    <span class="inbox-message-preview">${lastMessage.reason ? 'Accepted conversation' : lastMessage.message_data.text.startsWith('dmservice_reaction_') ? `${lastMessage.message_data.sender_id === user.id_str ? 'You reacted to message' : `${escapeHTML(messageUsers[0].name)} reacted to message`}` : escapeHTML(lastMessage.message_data.text)}</span>
                 </div>
             `;
             if(vars.enableTwemoji) {

--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -577,9 +577,9 @@ let userDataFunction = async user => {
                 isUnread = true;
             }
             messageElement.innerHTML = /*html*/`
-                <img src="${messageUsers.length === 1 ? messageUsers[0].profile_image_url_https : c.avatar_image_https}" width="48" height="48" class="inbox-message-avatar">
+                <img src="${messageUsers.length === 1 ? messageUsers[0].profile_image_url_https : (c.avatar_image_https || chrome.runtime.getURL(`/images/group.jpg`))}" width="48" height="48" class="inbox-message-avatar">
                 <div class="inbox-text">
-                    <b class="inbox-name">${messageUsers.length === 1 ? escapeHTML(messageUsers[0].name) : escapeHTML(c.name)}</b>
+                    <b class="inbox-name">${messageUsers.length === 1 ? escapeHTML(messageUsers[0].name) : (c.name ? escapeHTML(c.name) : messageUsers.map(i => escapeHTML(i.name)).join(', ').slice(0, 128))}</b>
                     <span class="inbox-screenname">${messageUsers.length === 1 ? "@"+messageUsers[0].screen_name : ''}</span>
                     <span class="inbox-time">${timeElapsed(new Date(+lastMessage.time))}</span>
                     <br>
@@ -599,8 +599,8 @@ let userDataFunction = async user => {
                 modal.querySelector('.name-top').hidden = false;
                 modal.querySelector('.inbox').hidden = true;
                 modal.querySelector('.new-message-box').hidden = true;
-                messageHeaderName.innerText = messageUsers.length === 1 ? messageUsers[0].name : c.name;
-                messageHeaderAvatar.src = messageUsers.length === 1 ? messageUsers[0].profile_image_url_https : c.avatar_image_https;
+                messageHeaderName.innerText = messageUsers.length === 1 ? messageUsers[0].name : (c.name || messageUsers.map(i => escapeHTML(i.name)).join(', ').slice(0, 128));
+                messageHeaderAvatar.src = messageUsers.length === 1 ? messageUsers[0].profile_image_url_https : (c.avatar_image_https || chrome.runtime.getURL(`/images/group.jpg`));
                 if(messageUsers.length === 1) messageHeaderLink.href = `https://twitter.com/${messageUsers[0].screen_name}`;
                 setTimeout(() => {
                     modal.querySelector(".message-new-input").focus();

--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -577,9 +577,9 @@ let userDataFunction = async user => {
                 isUnread = true;
             }
             messageElement.innerHTML = /*html*/`
-                <img src="${messageUsers.length === 1 ? messageUsers[0].profile_image_url_https : chrome.runtime.getURL(`/images/group.jpg`)}" width="48" height="48" class="inbox-message-avatar">
+                <img src="${messageUsers.length === 1 ? messageUsers[0].profile_image_url_https : c.avatar_image_https}" width="48" height="48" class="inbox-message-avatar">
                 <div class="inbox-text">
-                    <b class="inbox-name">${messageUsers.length === 1 ? escapeHTML(messageUsers[0].name) : messageUsers.map(i => escapeHTML(i.name)).join(', ').slice(0, 128)}</b>
+                    <b class="inbox-name">${messageUsers.length === 1 ? escapeHTML(messageUsers[0].name) : escapeHTML(c.name)}</b>
                     <span class="inbox-screenname">${messageUsers.length === 1 ? "@"+messageUsers[0].screen_name : ''}</span>
                     <span class="inbox-time">${timeElapsed(new Date(+lastMessage.time))}</span>
                     <br>
@@ -599,8 +599,8 @@ let userDataFunction = async user => {
                 modal.querySelector('.name-top').hidden = false;
                 modal.querySelector('.inbox').hidden = true;
                 modal.querySelector('.new-message-box').hidden = true;
-                messageHeaderName.innerText = messageUsers.length === 1 ? messageUsers[0].name : messageUsers.map(i => i.name).join(', ').slice(0, 80);
-                messageHeaderAvatar.src = messageUsers.length === 1 ? messageUsers[0].profile_image_url_https : chrome.runtime.getURL(`/images/group.jpg`);
+                messageHeaderName.innerText = messageUsers.length === 1 ? messageUsers[0].name : c.name;
+                messageHeaderAvatar.src = messageUsers.length === 1 ? messageUsers[0].profile_image_url_https : c.avatar_image_https;
                 if(messageUsers.length === 1) messageHeaderLink.href = `https://twitter.com/${messageUsers[0].screen_name}`;
                 setTimeout(() => {
                     modal.querySelector(".message-new-input").focus();

--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -599,7 +599,7 @@ let userDataFunction = async user => {
                 modal.querySelector('.name-top').hidden = false;
                 modal.querySelector('.inbox').hidden = true;
                 modal.querySelector('.new-message-box').hidden = true;
-                messageHeaderName.innerText = messageUsers.length === 1 ? messageUsers[0].name : (c.name || messageUsers.map(i => escapeHTML(i.name)).join(', ').slice(0, 128));
+                messageHeaderName.innerText = messageUsers.length === 1 ? messageUsers[0].name : (c.name || messageUsers.map(i => i.name).join(', ').slice(0, 80));
                 messageHeaderAvatar.src = messageUsers.length === 1 ? messageUsers[0].profile_image_url_https : (c.avatar_image_https || chrome.runtime.getURL(`/images/group.jpg`));
                 if(messageUsers.length === 1) messageHeaderLink.href = `https://twitter.com/${messageUsers[0].screen_name}`;
                 setTimeout(() => {


### PR DESCRIPTION
i have no idea if this was intended or just an "ill do it later" type of thing, but every group dm had its name as a list of all participants and a default icon, which is kind of hard to deal with if ur in multiple group dms

so, i added group dm names and icons, and used the old system as a fallback for group dms which actually have no names or icons, and i also fixed dm text previews saying "dmservice_reaction_one_to_one_media" which would happen because it only checked for "dmservice_reaction_one_to_one_text"