### PR TITLE
rewrite tweet language detection

### DIFF
--- a/scripts/tweetviewer.js
+++ b/scripts/tweetviewer.js
@@ -809,15 +809,16 @@ class TweetViewer {
         }
         let full_text = t.full_text ? t.full_text : '';
         full_text = Array.from(full_text).slice(t.display_text_range[0], t.display_text_range[1]).join(''); //Array.from helps with parsing emojis correctly, otherwise this may cut off 2 byte emojis
-        let textWithoutLinks = full_text.replace(/(?:https?|ftp):\/\/[\n\S]+/g, '').replace(/(?<!\w)@([\w+]{1,15}\b)/g, '');
-        let isEnglish
-        try { 
-            isEnglish = textWithoutLinks.length < 1 ? {languages:[{language:LANGUAGE, percentage:100}]} : await chrome.i18n.detectLanguage(textWithoutLinks);
-        } catch(e) {
-            isEnglish = {languages:[{language:LANGUAGE, percentage:100}]};
-            console.error(e);
-        }
-        isEnglish = isEnglish.languages[0] && isEnglish.languages[0].percentage > 60 && isEnglish.languages[0].language.startsWith(LANGUAGE);
+        let strippedDownText = full_text
+        .replace(/(?:https?|ftp):\/\/[\n\S]+/g, '') //links
+        .replace(/(?<!\w)@([\w+]{1,15}\b)/g, '') //mentions
+        .replace(/[\p{Extended_Pictographic}]/gu, '') //emojis (including ones that arent colored)
+        .replace(/[\u200B-\u200D\uFE0E\uFE0F]/g, '') //sometimes emojis leave these behind
+        .replace(/\d+/g, '') //numbers
+        .trim();
+        let detectedLanguage = strippedDownText.length < 1 ? {languages:[{language:LANGUAGE, percentage:100}]} : await chrome.i18n.detectLanguage(strippedDownText);
+        if(!detectedLanguage.languages[0]) detectedLanguage = {languages:[{language:t.lang, percentage:100}]}; //fallback to what twitter says
+        let isEnglish = detectedLanguage.languages[0] && detectedLanguage.languages[0].percentage > 60 && detectedLanguage.languages[0].language.startsWith(LANGUAGE);
         let videos = t.extended_entities && t.extended_entities.media && t.extended_entities.media.filter(m => m.type === 'video');
         if(!videos || videos.length === 0) {
             videos = undefined;


### PR DESCRIPTION
this seems like an unneeded change, and it mostly is, so i dont mind if this pr is denied or whatever

the original code would remove all links and mentions from the tweet text, then ask chrome.i18n.detectLanguage what language it was, then follow through with it if it claimed it were accurate

my code removes all links, mentions, emojis (this one happened more than youd think), and numbers, then asks chrome.i18n.detectLanguage what language it is, and if it couldn't figure it out at all then it would just go with what twitter claimed the tweet language was, and otherwise if it claims it is accurate then it follows through with it like before

this isn't THAT much better (mainly fixes issues with emojis by themselves being detected), but i find it to function better than twitters original one does in the first place (oldtwitters already functioned better than twitters though), and i feel like the original code needed a rewrite anyways