### PR TITLE
Change donate button css to prevent collision on (C)J(K) languages

### DIFF
--- a/layouts/header/style.css
+++ b/layouts/header/style.css
@@ -1624,6 +1624,7 @@ emoji-picker {
     animation: donate 5s infinite alternate, vibrate 10s infinite linear;
     position: absolute;
     transition: 1s;
+    word-break: keep-all;
 }
 @keyframes donate {
     20% {


### PR DESCRIPTION
<img width="146" alt="Image showing the Donate button in Japanese colliding with text below" src="https://github.com/dimdenGD/OldTwitter/assets/75546613/3b824a69-ce79-42b0-9a4a-2a11db995d86">

`donate-button` text in Japanese breaks to wrap which collides with lower `about-links` as there is no vertical gap. Changed `word-break` style on `donate-button` to prevent the text breaking. This CSS change should only affect Chinese, Japanese and Korean characters.

`word-break` could be changed on all `about-links a` to prevent mid-word breaking and make it look nicer, but I don't know how that will affect Chinese or Korean, so I haven't made that change.