### PR TITLE
fix being unable to see quoted tweets from users who blocked the author

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1338,6 +1338,13 @@ async function appendTweet(t, timelineContainer, options = {}) {
         if(t.withheld_in_countries && (t.withheld_in_countries.includes("XX") || t.withheld_in_countries.includes("XY"))) {
             full_text = "";
         }
+        if(t.quoted_status_id_str && !t.quoted_status) { //t.quoted_status is undefined if the user blocked the quoter (this also applies to deleted/private tweets too, but it just results in original behavior then)
+            try {
+                t.quoted_status = await API.getTweet(t.quoted_status_id_str);
+            } catch {
+                t.quoted_status = undefined;
+            }
+        }
         tweet.innerHTML = /*html*/`
             <div class="tweet-top" hidden></div>
             <a class="tweet-avatar-link" href="https://twitter.com/${t.user.screen_name}"><img onerror="this.src = 'https://abs.twimg.com/sticky/default_profile_images/default_profile_bigger.png'" src="${t.user.profile_image_url_https.replace("_normal.", "_bigger.")}" alt="${t.user.name}" class="tweet-avatar" width="48" height="48"></a>

--- a/scripts/tweetviewer.js
+++ b/scripts/tweetviewer.js
@@ -852,6 +852,13 @@ class TweetViewer {
         if(t.withheld_in_countries && (t.withheld_in_countries.includes("XX") || t.withheld_in_countries.includes("XY"))) {
             full_text = "";
         }
+        if(t.quoted_status_id_str && !t.quoted_status) { //t.quoted_status is undefined if the user blocked the quoter (this also applies to deleted/private tweets too, but it just results in original behavior then)
+            try {
+                t.quoted_status = await API.getTweet(t.quoted_status_id_str);
+            } catch {
+                t.quoted_status = undefined;
+            }
+        }
         tweet.innerHTML = /*html*/`
             <div class="tweet-top" hidden></div>
             <a class="tweet-avatar-link" href="https://twitter.com/${t.user.screen_name}"><img onerror="this.src = 'https://abs.twimg.com/sticky/default_profile_images/default_profile_bigger.png'" src="${t.user.profile_image_url_https.replace("_normal.", "_bigger.")}" alt="${t.user.name}" class="tweet-avatar" width="48" height="48"></a>


### PR DESCRIPTION
this is a real twitter bug, not oldtwitter

i have no idea how else to describe it so heres a before and after:

newtwitter:
![image](https://github.com/dimdenGD/OldTwitter/assets/70299052/0c6c5c36-7340-4d8c-914d-403b15abdf65)
oldtwitter (fix):
![image](https://github.com/dimdenGD/OldTwitter/assets/70299052/a2d52183-6f16-468d-8b86-12b76dc6aeab)

to fix it, i just check if it includes the quote tweet data in the tweet data, if it doesnt, it still usually returns the quote tweet's id, so i get the tweet data with the id instead