### PR TITLE
sort of fix #218 (my fault)

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1338,9 +1338,14 @@ async function appendTweet(t, timelineContainer, options = {}) {
         if(t.withheld_in_countries && (t.withheld_in_countries.includes("XX") || t.withheld_in_countries.includes("XY"))) {
             full_text = "";
         }
-        if(t.quoted_status_id_str && !t.quoted_status) { //t.quoted_status is undefined if the user blocked the quoter (this also applies to deleted/private tweets too, but it just results in original behavior then)
+        if(t.quoted_status_id_str && !t.quoted_status && options.mainTweet) { //t.quoted_status is undefined if the user blocked the quoter (this also applies to deleted/private tweets too, but it just results in original behavior then)
             try {
-                t.quoted_status = await API.getTweet(t.quoted_status_id_str);
+                if(t.quoted_status_result && t.quoted_status_result.result.tweet) {
+                    t.quoted_status = t.quoted_status_result.result.tweet.legacy;
+                    t.quoted_status.user = t.quoted_status_result.result.tweet.core.user_results.result.legacy;
+                } else {
+                    t.quoted_status = await API.getTweet(t.quoted_status_id_str);
+                }
             } catch {
                 t.quoted_status = undefined;
             }

--- a/scripts/tweetviewer.js
+++ b/scripts/tweetviewer.js
@@ -852,9 +852,14 @@ class TweetViewer {
         if(t.withheld_in_countries && (t.withheld_in_countries.includes("XX") || t.withheld_in_countries.includes("XY"))) {
             full_text = "";
         }
-        if(t.quoted_status_id_str && !t.quoted_status) { //t.quoted_status is undefined if the user blocked the quoter (this also applies to deleted/private tweets too, but it just results in original behavior then)
+        if(t.quoted_status_id_str && !t.quoted_status && options.mainTweet) { //t.quoted_status is undefined if the user blocked the quoter (this also applies to deleted/private tweets too, but it just results in original behavior then)
             try {
-                t.quoted_status = await API.getTweet(t.quoted_status_id_str);
+                if(t.quoted_status_result && t.quoted_status_result.result.tweet) {
+                    t.quoted_status = t.quoted_status_result.result.tweet.legacy;
+                    t.quoted_status.user = t.quoted_status_result.result.tweet.core.user_results.result.legacy;
+                } else {
+                    t.quoted_status = await API.getTweet(t.quoted_status_id_str);
+                }
             } catch {
                 t.quoted_status = undefined;
             }


### PR DESCRIPTION
this was caused by my pr (#209)

to fix it i basically just made it only work on main tweets (like /status/ pages and when you click a tweet on the tl) which is basically what the normal twitter client does, and also checked for t.quoted_status_result which can have the quote tweet data in certain circumstances

the reason i couldnt check if the user was blocking them is because when you fetch a tweet, it doesn't tell you that for some ungodly reason, and t.quoted_status_result is only there if you're blocking the user and the user isn't blocking the author (why?)