### PR TITLE
fix #231 (long tweets cut off)

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1297,7 +1297,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
             }
         }
         let full_text = t.full_text ? t.full_text : '';
-        if(location.pathname.includes('/status/')) full_text = Array.from(full_text).slice(t.display_text_range[0], t.display_text_range[1]).join(''); //Array.from helps with parsing emojis correctly, otherwise this may cut off 2 byte emojis
+        if(location.pathname.includes('/status/') && full_text.length < 281) full_text = Array.from(full_text).slice(t.display_text_range[0], t.display_text_range[1]).join(''); //Array.from helps with parsing emojis correctly, otherwise this may cut off 2 byte emojis
         let strippedDownText = full_text
         .replace(/(?:https?|ftp):\/\/[\n\S]+/g, '') //links
         .replace(/(?<!\w)@([\w+]{1,15}\b)/g, '') //mentions


### PR DESCRIPTION
my fault, but to be fair i didnt even know that note tweets existed in the first place, nor did i know that they were implemented differently

to fix this, i just added a check to my original code for fixing the mentions cut off issue that checks if the tweet is not a note tweet first (by checking if the length is 280 or lower), since note tweets dont even tell you what display text range they have