### PR TITLE
Fix for limited tweets not showing in bookmarks

### DIFF
--- a/scripts/apis.js
+++ b/scripts/apis.js
@@ -3532,6 +3532,9 @@ API.getBookmarks = (cursor) => {
             resolve({
                 list: list.filter(e => e.entryId.startsWith('tweet-')).map(e => {
                     let res = e.content.itemContent.tweet_results.result;
+                    if (res && res.__typename == 'TweetWithVisibilityResults') {
+                        res = res.tweet;
+                    }
                     if(!res || !res.legacy) return;
                     let tweet = res.legacy;
                     tweet.user = res.core.user_results.result.legacy;


### PR DESCRIPTION
Tweets that has limitations to who can reply are not showing in bookmarks due to the actual tweet content being inside `result.tweet` for these kind of tweets.