### PR TITLE
Remove followers texts completely

### DIFF
--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -84,7 +84,9 @@ function hideStuff() {
     if(vars.hideFollowers) {
         hideStyle.innerHTML += `
             #user-followers { display: none !important; }
+            #user-followers-div { display: none !important; }
             #profile-stat-followers-value { display: none !important; }
+            #profile-stat-followers-link { display: none !important; }
         `;
     }
     if(hideStyle.innerHTML !== '') {

--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -83,9 +83,7 @@ function hideStuff() {
     }
     if(vars.hideFollowers) {
         hideStyle.innerHTML += `
-            #user-followers { display: none !important; }
             #user-followers-div { display: none !important; }
-            #profile-stat-followers-value { display: none !important; }
             #profile-stat-followers-link { display: none !important; }
         `;
     }


### PR DESCRIPTION
The empty "followers" slots look goofy imo so I just made it so they get removed completely.

before (user-followers-div)
![image](https://github.com/dimdenGD/OldTwitter/assets/87461596/05e57ab8-be41-4842-937b-775fdb48c1ef)


after (user-followers-div)
![image](https://github.com/dimdenGD/OldTwitter/assets/87461596/d85760e2-07f9-410c-bdd8-0c0901adb1f1)
---

before (profile-stat-followers-link)
![image](https://github.com/dimdenGD/OldTwitter/assets/87461596/4dc42372-a6f1-483a-b898-cfb461503908)

after (profile-stat-followers-link)
![image](https://github.com/dimdenGD/OldTwitter/assets/87461596/5c57409e-0405-4aca-86be-5bb288d0317d)


