### PR TITLE
replace all .getTweets with .tweetDetail (old endpoint broke)

### DIFF
--- a/layouts/tweet/script.js
+++ b/layouts/tweet/script.js
@@ -234,7 +234,7 @@ async function updateLikes(id, c) {
 
     if(!c) {
         likeDiv.innerHTML = '';
-        let tweet = await appendTweet(await API.getTweet(id), likeDiv, {
+        let tweet = await appendTweet(await API.tweetDetail(id), likeDiv, { //th line
             mainTweet: true
         });
         tweet.style.borderBottom = '1px solid var(--border)';
@@ -277,7 +277,7 @@ async function updateRetweets(id, c) {
 
     if(!c) {
         retweetDiv.innerHTML = '';
-        let tweetData = await API.getTweet(id);
+        let tweetData = await API.tweetDetail(id);
         let tweet = await appendTweet(tweetData, retweetDiv, {
             mainTweet: true
         });
@@ -345,7 +345,7 @@ async function updateRetweetsWithComments(id, c) {
     let retweetDiv = document.getElementById('retweets_with_comments');
 
     if(!c) {
-        let t = await API.getTweet(id);
+        let t = await API.tweetDetail(id);
         retweetDiv.innerHTML = '';
         let h1 = document.createElement('h1');
         h1.innerHTML = `${LOC.quote_tweets.message} (<a href="https://twitter.com/aabehhh/status/${id}/retweets">${LOC.see_retweets.message}</a>)`;
@@ -872,7 +872,7 @@ setTimeout(async () => {
     if(/^\/i\/web\/status\/(\d{5,32})(|\/)$/.test(realPath)) {
         let id = realPath.split("/i/web/status/")[1];
         if (id.endsWith("/")) id = id.slice(0, -1);
-        let tweet = await API.getTweet(id);
+        let tweet = await API.tweetDetail(id);
         location.replace(`https://twitter.com/${tweet.user.screen_name}/status/${id}`);
         return;
     }

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1333,7 +1333,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
                     t.quoted_status = t.quoted_status_result.result.tweet.legacy;
                     t.quoted_status.user = t.quoted_status_result.result.tweet.core.user_results.result.legacy;
                 } else {
-                    t.quoted_status = await API.getTweet(t.quoted_status_id_str);
+                    t.quoted_status = await API.tweetDetail(t.quoted_status_id_str);
                 }
             } catch {
                 t.quoted_status = undefined;
@@ -2661,7 +2661,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
         tweetInteractMoreMenuRefresh.addEventListener('click', async () => {
             let tweetData;
             try {
-                tweetData = await API.getTweet(t.id_str);
+                tweetData = await API.tweetDetail(t.id_str);
             } catch (e) {
                 console.error(e);
                 return;

--- a/scripts/tweetviewer.js
+++ b/scripts/tweetviewer.js
@@ -283,7 +283,7 @@ class TweetViewer {
     
         if(!c) {
             likeDiv.innerHTML = '';
-            let tweetData = await API.getTweet(id);
+            let tweetData = await API.tweetDetail(id);
             let tweet = await this.appendTweet(tweetData, likeDiv, {
                 mainTweet: true
             });
@@ -323,7 +323,7 @@ class TweetViewer {
     
         if(!c) {
             retweetDiv.innerHTML = '';
-            let tweetData = await API.getTweet(id);
+            let tweetData = await API.tweetDetail(id);
             let tweet = await this.appendTweet(tweetData, retweetDiv, {
                 mainTweet: true
             });
@@ -397,7 +397,7 @@ class TweetViewer {
         let tvl = this.container.getElementsByClassName('tweet-viewer-loading')[0];
         tvl.hidden = false;
         let tweetRetweeters;
-        let tweetData = await API.getTweet(id);
+        let tweetData = await API.tweetDetail(id);
         try {
             tweetRetweeters = await API.getTweetQuotes(id, c);
             this.retweetCommentsCursor = tweetRetweeters.cursor;
@@ -417,7 +417,7 @@ class TweetViewer {
             retweetDiv.appendChild(h1);
             h1.getElementsByTagName('a')[0].addEventListener('click', async e => {
                 e.preventDefault();
-                let t = await API.getTweet(id);
+                let t = await API.tweetDetail(id);
                 history.pushState({}, null, `https://twitter.com/${tweetData.user.screen_name}/status/${id}/retweets`);
                 this.updateSubpage();
                 this.mediaToUpload = [];
@@ -854,7 +854,7 @@ class TweetViewer {
                     t.quoted_status = t.quoted_status_result.result.tweet.legacy;
                     t.quoted_status.user = t.quoted_status_result.result.tweet.core.user_results.result.legacy;
                 } else {
-                    t.quoted_status = await API.getTweet(t.quoted_status_id_str);
+                    t.quoted_status = await API.tweetDetail(t.quoted_status_id_str);
                 }
             } catch {
                 t.quoted_status = undefined;
@@ -2022,7 +2022,7 @@ class TweetViewer {
         tweetInteractMoreMenuRefresh.addEventListener('click', async () => {
             let tweetData;
             try {
-                tweetData = await API.getTweet(t.id_str);
+                tweetData = await API.tweetDetail(t.id_str);
             } catch (e) {
                 console.error(e);
                 return;


### PR DESCRIPTION
the old endpoint just returns a 403 now, so i just replaced all instances of getTweet (wasnt sure if i should just remove API.getTweet altogether, so i kept it for now)

this also fixes being unable to see users who liked and retweeted a tweet