### PR TITLE
fixed "user reacted to message" subtitle in group dms

### DIFF
--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -602,6 +602,7 @@ let userDataFunction = async user => {
                 lastMessage = lastMessage.trust_conversation;
             };
             let messageUsers = c.participants.filter(p => p.user_id !== user.id_str).map(p => inbox.users[p.user_id]);
+            let lastMessageUser = messageUsers.find(user => user.id_str === lastMessage.message_data.sender_id);
             let messageElement = document.createElement('div');
             messageElement.classList.add('inbox-message');
             let isUnread = false;
@@ -617,7 +618,7 @@ let userDataFunction = async user => {
                     <span class="inbox-screenname">${messageUsers.length === 1 ? "@"+messageUsers[0].screen_name : ''}</span>
                     <span class="inbox-time">${timeElapsed(new Date(+lastMessage.time))}</span>
                     <br>
-                    <span class="inbox-message-preview">${lastMessage.reason ? 'Accepted conversation' : lastMessage.message_data.text.startsWith('dmservice_reaction_') ? `${lastMessage.message_data.sender_id === user.id_str ? 'You reacted to message' : `${escapeHTML(messageUsers[0].name)} reacted to message`}` : escapeHTML(lastMessage.message_data.text)}</span>
+                    <span class="inbox-message-preview">${lastMessage.reason ? 'Accepted conversation' : lastMessage.message_data.text.startsWith('dmservice_reaction_') ? `${lastMessage.message_data.sender_id === user.id_str ? 'You reacted to message' : `${escapeHTML(lastMessageUser.name)} reacted to message`}` : escapeHTML(lastMessage.message_data.text)}</span>
                 </div>
             `;
             if(vars.enableTwemoji) {


### PR DESCRIPTION
it used to say the first person in the group dm no matter who reacted to a message, so if the first person was named "first" and the second person reacted, it'd still say first reacted

now it gets the specific user from messageUsers and uses that users name instead