### PR TITLE
Redirect x.com to twitter.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,8 @@
   "host_permissions": [
     "*://*.twitter.com/*",
     "*://twitter.com/*",
+    "*://*.x.com/*",
+    "*://x.com/*",
     "*://twimg.com/*",
     "*://*.twimg.com/*"
   ],

--- a/scripts/background_v2.js
+++ b/scripts/background_v2.js
@@ -11,6 +11,10 @@ chrome.webRequest.onBeforeRequest.addListener(
             return {
                 redirectUrl: chrome.runtime.getURL('images/logo32_new_notification.png')
             };
+        } else if (details.url.includes('x.com')) {
+            return {
+                redirectUrl: chrome.runtime.getURL(details.url.replace('x.com', 'twitter.com')) // https://i.insider.com/5d5302c6cd97841bc207b2e4?format=jpeg
+            }
         }
         return {
             cancel:


### PR DESCRIPTION
As of right now, all this PR does is make x.com redirect to twitter.com in the browser. When Elon switches it around on their end, you'll have to find a way to block that 301 (or 302 if Elon's really dumb) redirect to x.com and make the OldTwitter UI from there.

The good thing about the twitter.com to x.com redirect is that if you can block the redirect, the page is a blank slate, no new twitter to worry about.

![Elon Musk with Ghislaine Maxwell. Look at how happy they are together! 😊](https://i.insider.com/5d5302c6cd97841bc207b2e4?format=jpeg)