### PR TITLE
add twitter blue rich text support (and fix a few things)

### DIFF
--- a/scripts/apis.js
+++ b/scripts/apis.js
@@ -37,13 +37,15 @@ function debugLog(...args) {
 // extract full text and url entities from "note_tweet"
 function parseNoteTweet(result) {
     let text, entities;
-    if(result.note_tweet.note_tweet_results.entity_set) {
-        entities = result.note_tweet.note_tweet_results.entity_set;
-    }
-    text = result.note_tweet.note_tweet_results.text;
-    if(typeof text !== "string") {
+    if(result.note_tweet.note_tweet_results.result) {
         text = result.note_tweet.note_tweet_results.result.text;
         entities = result.note_tweet.note_tweet_results.result.entity_set;
+        if(result.note_tweet.note_tweet_results.result.richtext?.richtext_tags.length) {
+            entities.richtext = result.note_tweet.note_tweet_results.result.richtext.richtext_tags // logically, richtext is an entity, right?
+        }
+    } else {
+        text = result.note_tweet.note_tweet_results.text;
+        entities = result.note_tweet.note_tweet_results.entity_set;
     }
     return {text, entities};
 }

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -554,8 +554,9 @@ function generatePoll(tweet, tweetElement, user) {
     let choices = Object.keys(poll).filter(key => key.endsWith('label')).map((key, i) => ({
         label: poll[key].string_value,
         count: poll[key.replace('label', 'count')] ? +poll[key.replace('label', 'count')].string_value : 0,
-        id: i+1
+        id: parseInt(key.replace(/[^0-9]/g, ''))
     }));
+    choices.sort((a, b) => a.id - b.id);
     let voteCount = choices.reduce((acc, cur) => acc + cur.count, 0);
     if(poll.selected_choice || user.id_str === tweet.user.id_str || (poll.counts_are_final && poll.counts_are_final.boolean_value)) {
         for(let i in choices) {

--- a/scripts/tweetviewer.js
+++ b/scripts/tweetviewer.js
@@ -913,7 +913,7 @@ class TweetViewer {
             </div>
             <a ${options.mainTweet ? 'hidden' : ''} class="tweet-time" data-timestamp="${new Date(t.created_at).getTime()}" title="${new Date(t.created_at).toLocaleString()}" href="https://twitter.com/${t.user.screen_name}/status/${t.id_str}">${timeElapsed(new Date(t.created_at).getTime())}</a>
             <div class="tweet-body ${options.mainTweet ? 'tweet-body-main' : ''}">
-                <span class="tweet-body-text ${vars.noBigFont || (full_text && full_text.length > 100) || !options.mainTweet ? 'tweet-body-text-long' : 'tweet-body-text-short'}">${vars.useOldStyleReply ? /*html*/mentionedUserText: ''}${full_text ? await renderTweetBodyHTML(full_text, t.entities, t.display_text_range) : ''}</span>
+                <span class="tweet-body-text ${vars.noBigFont || (full_text && full_text.length > 100) || !options.mainTweet ? 'tweet-body-text-long' : 'tweet-body-text-short'}">${vars.useOldStyleReply ? /*html*/mentionedUserText: ''}${full_text ? await renderTweetBodyHTML(t) : ''}</span>
                 ${!isEnglish ? /*html*/`
                 <br>
                 <span class="tweet-translate">${LOC.view_translation.message}</span>
@@ -955,7 +955,7 @@ class TweetViewer {
                     ${quoteMentionedUserText !== `` && !vars.useOldStyleReply ? /*html*/`
                     <span class="tweet-reply-to tweet-quote-reply-to">${LOC.replying_to_user.message.replace('$SCREEN_NAME$', quoteMentionedUserText.trim().replaceAll(` `, LOC.replying_to_comma.message).replace(LOC.replying_to_comma.message, LOC.replying_to_and.message))}</span>
                     ` : ''}
-                    <span class="tweet-body-text tweet-body-text-quote tweet-body-text-long" style="color:var(--default-text-color)!important">${vars.useOldStyleReply? quoteMentionedUserText : ''}${t.quoted_status.full_text ? await renderTweetBodyHTML(t.quoted_status.full_text, t.quoted_status.entities, t.quoted_status.display_text_range, true) : ''}</span>
+                    <span class="tweet-body-text tweet-body-text-quote tweet-body-text-long" style="color:var(--default-text-color)!important">${vars.useOldStyleReply? quoteMentionedUserText : ''}${t.quoted_status.full_text ? await renderTweetBodyHTML(t, true) : ''}</span>
                     ${t.quoted_status.extended_entities && t.quoted_status.extended_entities.media ? /*html*/`
                     <div class="tweet-media-quote">
                         ${t.quoted_status.extended_entities.media.map(m => `<${m.type === 'photo' ? 'img' : 'video'} ${m.ext_alt_text ? `alt="${escapeHTML(m.ext_alt_text)}" title="${escapeHTML(m.ext_alt_text)}"` : ''} crossorigin="anonymous" width="${quoteSizeFunctions[t.quoted_status.extended_entities.media.length](m.original_info.width, m.original_info.height)[0]}" height="${quoteSizeFunctions[t.quoted_status.extended_entities.media.length](m.original_info.width, m.original_info.height)[1]}" loading="lazy" ${m.type === 'video' ? 'controls' : ''} ${m.type === 'animated_gif' ? 'loop muted onclick="if(this.paused) this.play(); else this.pause()"' : ''}${m.type === 'animated_gif' && !vars.disableGifAutoplay ? ' autoplay' : ''} src="${m.type === 'photo' ? m.media_url_https : m.video_info.variants.find(v => v.content_type === 'video/mp4').url}" class="tweet-media-element tweet-media-element-quote ${mediaClasses[t.quoted_status.extended_entities.media.length]} ${!vars.displaySensitiveContent && t.quoted_status.possibly_sensitive ? 'tweet-media-element-censor' : ''}">${m.type === 'video' ? '</video>' : ''}`).join('\n')}
@@ -1430,10 +1430,14 @@ class TweetViewer {
             } else {
                 translatedMessage = `${LOC.translated_from.message} [${translated.translated_lang}]`;
             }
+            let translatedT = {
+                full_text: translated.text,
+                entities: translated.entities
+            }
             tweetBodyText.innerHTML += `<br>`+
             `<span style="font-size: 12px;color: var(--light-gray);">${translatedMessage}:</span>`+
             `<br>`+
-            `<span class="tweet-translated-text">${await renderTweetBodyHTML(translated.text, translated.entities)}</span>`;
+            `<span class="tweet-translated-text">${await renderTweetBodyHTML(translatedT)}</span>`;
             if(vars.enableTwemoji) twemoji.parse(tweetBodyText);
         });
 


### PR DESCRIPTION
this pr adds rich text support for twitter blue tweets, fixes poll options sometimes showing out of order, fixes quote tweets being treated as the tweet they quoted (i have no idea how else to describe it), and fixes some random overcomplications

rich text is just treated as an entity by parseNoteTweet (rich text works on non note tweets btw), then renderTweetBodyHTML parses the richtext "entity" with b and i html tags (just like it parses links but with bold tags and italic tags, basically)

to fix poll options, instead of taking the i from the loop for the arbitrary choice keys (for some reason, this sometimes ends up out of order?), it just takes only the number from the key and uses that as the "id"

parseNoteTweet now takes t as input instead (because its harder to add new stuff with arbitrary limitations like only being able to supply text and entities), which i also used to fix the quote tweet issue
and parseNoteTweets code now reads better