### PR TITLE
fix suspended accounts breaking dms (and better fix for my #182)

### DIFF
--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -765,20 +765,6 @@ let userDataFunction = async user => {
             modal.getElementsByClassName('messages-load-more')[0].hidden = true;
             return;
         }
-        let missingUserIds = [];
-        for(let j in lastConvo.entries) {
-            let m = lastConvo.entries[j].message;
-            if(!m) continue;
-            if(!lastConvo.users[m.message_data.sender_id] && !missingUserIds.includes(m.message_data.sender_id)) {
-                missingUserIds.push(m.message_data.sender_id);
-            }
-        }
-        if(missingUserIds.length > 0) {
-            let foundUsers = await API.user.lookup(missingUserIds)
-            foundUsers.forEach(user => {
-                lastConvo.users[user.id_str] = user;
-            });
-        }
         lastConvo.entries = lastConvo.entries.reverse();
         let messageElements = [];
         for(let i in lastConvo.entries) {

--- a/scripts/apis.js
+++ b/scripts/apis.js
@@ -3854,7 +3854,7 @@ const API = {
         },
         getConversation: (id, max_id) => {
             return new Promise((resolve, reject) => {
-                fetch(`https://api.twitter.com/1.1/dm/conversation/${id}.json?ext=altText${max_id ? `&max_id=${max_id}` : ''}&count=100&cards_platform=Web-13&include_entities=1&include_user_entities=1&include_cards=1&send_error_codes=1&tweet_mode=extended&include_ext_alt_text=true&include_reply_count=true`, {
+                fetch(`https://api.twitter.com/1.1/dm/conversation/${id}.json?ext=altText${max_id ? `&max_id=${max_id}` : ''}&count=100&cards_platform=Web-13&include_entities=1&include_user_entities=1&include_cards=1&send_error_codes=1&tweet_mode=extended&include_ext_alt_text=true&include_reply_count=true&include_conversation_info=true`, {
                     headers: {
                         "authorization": OLDTWITTER_CONFIG.oauth_key,
                         "x-csrf-token": OLDTWITTER_CONFIG.csrf,


### PR DESCRIPTION
this pr adds `include_conversation_info=true` to the dm converastion endpoint, and removes the code i added in #182 because it is redundant compared to the flag. this fixes suspended accounts breaking dms, and also fixes the original problem in a more efficient way. i have no idea why or how i didn't find this the first time lol