### PR TITLE
Add yarn package manager compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _metadata/
 node_modules/
 package-lock.json
+yarn.lock

--- a/pack.js
+++ b/pack.js
@@ -252,8 +252,16 @@ copyDir('./', '../OldTwitterFirefox').then(async () => {
     fs.unlinkSync('../OldTwitterTempChrome/test.js');
     fs.unlinkSync('../OldTwitterFirefox/package.json');
     fs.unlinkSync('../OldTwitterTempChrome/package.json');
-    fs.unlinkSync('../OldTwitterFirefox/package-lock.json');
-    fs.unlinkSync('../OldTwitterTempChrome/package-lock.json');
+  
+    if (fs.existsSync('../OldTwitterFirefox/package-lock.json')) // Delete NPM package-lock (if exists)
+      fs.unlinkSync('../OldTwitterFirefox/package-lock.json');
+    if (fs.existsSync('../OldTwitterTempChrome/package-lock.json'))
+      fs.unlinkSync('../OldTwitterTempChrome/package-lock.json');
+  
+    if (fs.existsSync('../OldTwitterFirefox/yarn.lock')) // Delete yarn package-lock (if exists)
+      fs.unlinkSync('../OldTwitterFirefox/yarn.lock');
+    if (fs.existsSync('../OldTwitterTempChrome/yarn.lock'))
+      fs.unlinkSync('../OldTwitterTempChrome/yarn.lock');
 
     let layouts = fs.readdirSync('../OldTwitterFirefox/layouts');
     for (let layout of layouts) {


### PR DESCRIPTION
Hi, recently I've developed an interest in this project and would like to try poking around & fixing some bugs. I prefer the usability of the Yarn package manager however I ran into problems exporting the extension with Yarn as only NPM is supported. I have forked the extension and changed just two things so Yarn users are also able to work on this extension and build it.