### PR TITLE
Fix translations not using placeholders

### DIFF
--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -153,12 +153,20 @@
 		"message": "Deixar de seguir"
 	},
 	"follow_user": {
-		"message": "Seguir",
-		"example": "->Follow<- @CoolPerson2000"
+		"message": "Seguir @$SCREEN_NAME$",
+		"placeholders": {
+			"screen_name": {
+				"content": "CoolPerson2000"
+			}
+		}
 	},
 	"unfollow_user": {
-		"message": "Deixar de seguir",
-		"example": "->Unfollow<- @CoolPerson2000"
+		"message": "Deixar de seguir @$SCREEN_NAME$",
+		"placeholders": {
+			"screen_name": {
+				"content": "CoolPerson2000"
+			}
+		}
 	},
 	"thank_you_follow": {
 		"message": "Obrigado por me seguir!"


### PR DESCRIPTION
This PR should fix errors like this:

![image](https://github.com/dimdenGD/OldTwitter/assets/19615514/2cea2f27-1af0-4002-bc4a-49a838955702)
