### PR TITLE
Improved tweet click event handling.

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -14,34 +14,6 @@ function arrayBufferToBase64(buffer) {
 function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
-function isChildOfClass(element, className) {
-    var cur = element;
-    while (true) {
-        if (cur.className && cur.classList.contains(className)) {
-            return true;
-        }
-        if (cur.parentElement != null) {
-            cur = cur.parentElement;
-        } else {
-            break;
-        }
-    }
-    return false;
-}
-function isChildOfTag(element, tagName) {
-    var cur = element;
-    while (true) {
-        if (cur.tagName && cur.tagName.toUpperCase() == tagName.toUpperCase()) {
-            return true;
-        }
-        if (cur.parentElement != null) {
-            cur = cur.parentElement;
-        } else {
-            break;
-        }
-    }
-    return false;
-}
 function createModal(html, className, onclose, canclose) {
     let modal = document.createElement('div');
     modal.classList.add('modal');
@@ -1643,7 +1615,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
 
         if(!options.mainTweet && typeof mainTweetLikers !== 'undefined' && !location.pathname.includes("retweets/with_comments") && !document.querySelector('.modal')) {
             tweet.addEventListener('click', async e => {
-                if (!isChildOfClass(e.target, "tweet-button") && !isChildOfClass(e.target, "tweet-edit-section") && !isChildOfClass(e.target, "dropdown-menu") && !isChildOfClass(e.target, "tweet-media-element") && !isChildOfTag(e.target, "A") && !isChildOfTag(e.target, "BUTTON")) {
+                if (!e.target.closest(".tweet-button") && !e.target.closest(".tweet-edit-section") && !e.target.closest(".dropdown-menu") && !e.target.closest(".tweet-media-element") && !e.target.closest("a") && !e.target.closest("button")) {
                     document.getElementById('loading-box').hidden = false;
                     savePageData();
                     history.pushState({}, null, `https://twitter.com/${t.user.screen_name}/status/${t.id_str}`);
@@ -1672,7 +1644,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
         } else {
             if(!options.mainTweet) {
                 tweet.addEventListener('click', e => {
-                    if(!isChildOfClass(e.target, "tweet-button") && !isChildOfClass(e.target, "tweet-edit-section") && !isChildOfClass(e.target, "dropdown-menu") && !isChildOfClass(e.target, "tweet-media-element") && !isChildOfTag(e.target, "A") && !isChildOfTag(e.target, "BUTTON")) {
+                    if(!e.target.closest(".tweet-button") && !e.target.closest(".tweet-edit-section") && !e.target.closest(".dropdown-menu") && !e.target.closest(".tweet-media-element") && !e.target.closest("a") && !e.target.closest("button")) {
                         let tweetData = t;
                         if(tweetData.retweeted_status) tweetData = tweetData.retweeted_status;
                         tweet.classList.add('tweet-preload');
@@ -1688,7 +1660,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
         tweet.addEventListener('mousedown', e => {
             if(e.button === 1) {
                 // tweet-media-element is clickable, since it should open the tweet in a new tab.
-                if(!isChildOfClass(e.target, "tweet-button") && !isChildOfClass(e.target, "tweet-edit-section") && !isChildOfClass(e.target, "dropdown-menu") && !isChildOfTag(e.target, "A") && !isChildOfTag(e.target, "BUTTON")) {
+                if(!e.target.closest(".tweet-button") && !e.target.closest(".tweet-edit-section") && !e.target.closest(".dropdown-menu") && !e.target.closest("a") && !e.target.closest("button")) {
                     e.preventDefault();
                     openInNewTab(`https://twitter.com/${t.user.screen_name}/status/${t.id_str}`);
                 }

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -14,6 +14,34 @@ function arrayBufferToBase64(buffer) {
 function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
+function isChildOfClass(element, className) {
+    var cur = element;
+    while (true) {
+        if (cur.className && cur.classList.contains(className)) {
+            return true;
+        }
+        if (cur.parentElement != null) {
+            cur = cur.parentElement;
+        } else {
+            break;
+        }
+    }
+    return false;
+}
+function isChildOfTag(element, tagName) {
+    var cur = element;
+    while (true) {
+        if (cur.tagName && cur.tagName.toUpperCase() == tagName.toUpperCase()) {
+            return true;
+        }
+        if (cur.parentElement != null) {
+            cur = cur.parentElement;
+        } else {
+            break;
+        }
+    }
+    return false;
+}
 function createModal(html, className, onclose, canclose) {
     let modal = document.createElement('div');
     modal.classList.add('modal');
@@ -1615,7 +1643,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
 
         if(!options.mainTweet && typeof mainTweetLikers !== 'undefined' && !location.pathname.includes("retweets/with_comments") && !document.querySelector('.modal')) {
             tweet.addEventListener('click', async e => {
-                if(e.target.className && (e.target.classList.contains('tweet') || e.target.classList.contains('tweet-body') || e.target.classList.contains('tweet-reply-to') || e.target.className === 'tweet-interact' || e.target.className === 'tweet-media')) {
+                if (!isChildOfClass(e.target, "tweet-button") && !isChildOfClass(e.target, "tweet-edit-section") && !isChildOfClass(e.target, "dropdown-menu") && !isChildOfClass(e.target, "tweet-media-element") && !isChildOfTag(e.target, "A") && !isChildOfTag(e.target, "BUTTON")) {
                     document.getElementById('loading-box').hidden = false;
                     savePageData();
                     history.pushState({}, null, `https://twitter.com/${t.user.screen_name}/status/${t.id_str}`);
@@ -1641,18 +1669,10 @@ async function appendTweet(t, timelineContainer, options = {}) {
                     currentLocation = location.pathname;
                 }
             });
-            tweet.addEventListener('mousedown', e => {
-                if(e.button === 1) {
-                    e.preventDefault();
-                    if(e.target.className && (e.target.classList.contains('tweet') || e.target.classList.contains('tweet-body') || e.target.classList.contains('tweet-reply-to') || e.target.className === 'tweet-interact' || e.target.className === 'tweet-media')) {
-                        openInNewTab(`https://twitter.com/${t.user.screen_name}/status/${t.id_str}`);
-                    }
-                }
-            });
         } else {
             if(!options.mainTweet) {
                 tweet.addEventListener('click', e => {
-                    if(e.target.className && (e.target.classList.contains('tweet') || e.target.classList.contains('tweet-body') || e.target.classList.contains('tweet-reply-to') || e.target.className === 'tweet-interact' || e.target.className === 'tweet-media')) {
+                    if(!isChildOfClass(e.target, "tweet-button") && !isChildOfClass(e.target, "tweet-edit-section") && !isChildOfClass(e.target, "dropdown-menu") && !isChildOfClass(e.target, "tweet-media-element") && !isChildOfTag(e.target, "A") && !isChildOfTag(e.target, "BUTTON")) {
                         let tweetData = t;
                         if(tweetData.retweeted_status) tweetData = tweetData.retweeted_status;
                         tweet.classList.add('tweet-preload');
@@ -1663,16 +1683,17 @@ async function appendTweet(t, timelineContainer, options = {}) {
                         new TweetViewer(user, tweetData);
                     }
                 });
-                tweet.addEventListener('mousedown', e => {
-                    if(e.button === 1) {
-                        e.preventDefault();
-                        if(e.target.className && (e.target.classList.contains('tweet') || e.target.classList.contains('tweet-body') || e.target.classList.contains('tweet-reply-to') || e.target.className === 'tweet-interact')) {
-                            openInNewTab(`https://twitter.com/${t.user.screen_name}/status/${t.id_str}`);
-                        }
-                    }
-                });
             }
         }
+        tweet.addEventListener('mousedown', e => {
+            if(e.button === 1) {
+                // tweet-media-element is clickable, since it should open the tweet in a new tab.
+                if(!isChildOfClass(e.target, "tweet-button") && !isChildOfClass(e.target, "tweet-edit-section") && !isChildOfClass(e.target, "dropdown-menu") && !isChildOfTag(e.target, "A") && !isChildOfTag(e.target, "BUTTON")) {
+                    e.preventDefault();
+                    openInNewTab(`https://twitter.com/${t.user.screen_name}/status/${t.id_str}`);
+                }
+            }
+        });
         tweet.tabIndex = -1;
         tweet.className = `tweet ${options.mainTweet ? 'tweet-main' : location.pathname.includes('/status/') ? 'tweet-replying' : ''}`.trim();
         tweet.dataset.tweetId = t.id_str;
@@ -1847,7 +1868,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
                 </div>
                 ${!isMatchingLanguage && options.mainTweet ? /*html*/`
                 <br>
-                <span class="tweet-translate">${LOC.view_translation.message}</span>
+                <span class="tweet-button tweet-translate">${LOC.view_translation.message}</span>
                 ` : ``}
                 ${t.extended_entities && t.extended_entities.media ? /*html*/`
                     <div class="tweet-media">
@@ -1893,7 +1914,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
                     </div>
                     ` : ''}
                     ${!isQuoteMatchingLanguage ? /*html*/`
-                    <span class="tweet-quote-translate">${LOC.view_translation.message}</span>
+                    <span class="tweet-button tweet-quote-translate">${LOC.view_translation.message}</span>
                     ` : ``}
                 </a>
                 ` : ``}
@@ -1933,8 +1954,8 @@ async function appendTweet(t, timelineContainer, options = {}) {
                 ` : ''}
                 <a ${!options.mainTweet ? 'hidden' : ''} class="tweet-date" title="${new Date(t.created_at).toLocaleString()}" href="https://twitter.com/${t.user.screen_name}/status/${t.id_str}"><br>${new Date(t.created_at).toLocaleTimeString(undefined, { hour: 'numeric', minute: 'numeric' }).toLowerCase()} - ${new Date(t.created_at).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })}  ・ ${t.source ? t.source.split('>')[1].split('<')[0] : 'Unknown'}</a>
                 <div class="tweet-interact">
-                    <span class="tweet-interact-reply" title="${LOC.reply_btn.message}${!vars.disableHotkeys ? ' (R)' : ''}" data-val="${t.reply_count}">${options.mainTweet ? '' : formatLargeNumber(t.reply_count).replace(/\s/g, ',')}</span>
-                    <span title="${LOC.retweet_btn.message}" class="tweet-interact-retweet${t.retweeted ? ' tweet-interact-retweeted' : ''}${(t.user.protected || t.limited_actions === 'limit_trusted_friends_tweet') && t.user.id_str !== user.id_str ? ' tweet-interact-retweet-disabled' : ''}" data-val="${t.retweet_count}">${options.mainTweet ? '' : formatLargeNumber(t.retweet_count).replace(/\s/g, ',')}</span>
+                    <span class="tweet-button tweet-interact-reply" title="${LOC.reply_btn.message}${!vars.disableHotkeys ? ' (R)' : ''}" data-val="${t.reply_count}">${options.mainTweet ? '' : formatLargeNumber(t.reply_count).replace(/\s/g, ',')}</span>
+                    <span title="${LOC.retweet_btn.message}" class="tweet-button tweet-interact-retweet${t.retweeted ? ' tweet-interact-retweeted' : ''}${(t.user.protected || t.limited_actions === 'limit_trusted_friends_tweet') && t.user.id_str !== user.id_str ? ' tweet-interact-retweet-disabled' : ''}" data-val="${t.retweet_count}">${options.mainTweet ? '' : formatLargeNumber(t.retweet_count).replace(/\s/g, ',')}</span>
                     <div class="tweet-interact-retweet-menu dropdown-menu" hidden>
                         <span class="tweet-interact-retweet-menu-retweet">${t.retweeted ? LOC.unretweet.message : LOC.retweet.message}${!vars.disableHotkeys ? ' (T)' : ''}</span>
                         <span class="tweet-interact-retweet-menu-quote">${LOC.quote_tweet.message}${!vars.disableHotkeys ? ' (Q)' : ''}</span>
@@ -1943,12 +1964,12 @@ async function appendTweet(t, timelineContainer, options = {}) {
                             <span class="tweet-interact-retweet-menu-retweeters">${LOC.see_retweeters.message}</span>
                         ` : ''}
                     </div>
-                    <span title="${vars.heartsNotStars ? LOC.like_btn.message : LOC.favorite_btn.message}${!vars.disableHotkeys ? ' (L)' : ''}" class="tweet-interact-favorite ${t.favorited ? 'tweet-interact-favorited' : ''}" data-val="${t.favorite_count}">${options.mainTweet ? '' : formatLargeNumber(t.favorite_count).replace(/\s/g, ',')}</span>
+                    <span title="${vars.heartsNotStars ? LOC.like_btn.message : LOC.favorite_btn.message}${!vars.disableHotkeys ? ' (L)' : ''}" class="tweet-button tweet-interact-favorite ${t.favorited ? 'tweet-interact-favorited' : ''}" data-val="${t.favorite_count}">${options.mainTweet ? '' : formatLargeNumber(t.favorite_count).replace(/\s/g, ',')}</span>
                     ${(vars.showBookmarkCount || options.mainTweet) && typeof t.bookmark_count !== 'undefined' ? 
-                        /*html*/`<span title="${LOC.bookmarks_count.message}${!vars.disableHotkeys ? ' (B)' : ''}" class="tweet-interact-bookmark${t.bookmarked ? ' tweet-interact-bookmarked' : ''}" data-val="${t.bookmark_count}">${formatLargeNumber(t.bookmark_count).replace(/\s/g, ',')}</span>` :
+                        /*html*/`<span title="${LOC.bookmarks_count.message}${!vars.disableHotkeys ? ' (B)' : ''}" class="tweet-button tweet-interact-bookmark${t.bookmarked ? ' tweet-interact-bookmarked' : ''}" data-val="${t.bookmark_count}">${formatLargeNumber(t.bookmark_count).replace(/\s/g, ',')}</span>` :
                     ''}
                     ${vars.seeTweetViews && t.ext && t.ext.views && t.ext.views.r && t.ext.views.r.ok && t.ext.views.r.ok.count ? /*html*/`<span title="${LOC.views_count.message}" class="tweet-interact-views" data-val="${t.ext.views.r.ok.count}">${formatLargeNumber(t.ext.views.r.ok.count).replace(/\s/g, ',')}</span>` : ''}
-                    <span class="tweet-interact-more"></span>
+                    <span class="tweet-button tweet-interact-more"></span>
                     <div class="tweet-interact-more-menu dropdown-menu" hidden>
                         ${innerWidth < 590 ? /*html*/`
                         <span class="tweet-interact-more-menu-separate">${LOC.separate_text.message}</span>
@@ -1997,7 +2018,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
                     ${options.selfThreadButton && t.self_thread && t.self_thread.id_str && !options.threadContinuation && !location.pathname.includes('/status/') ? /*html*/`<a class="tweet-self-thread-button tweet-thread-right" target="_blank" href="https://twitter.com/${t.user.screen_name}/status/${t.self_thread.id_str}">${LOC.show_this_thread.message}</a>` : ``}
                     ${!options.noTop && !options.selfThreadButton && t.in_reply_to_status_id_str && !(options.threadContinuation || (options.selfThreadContinuation && t.self_thread && t.self_thread.id_str)) && !location.pathname.includes('/status/') ? `<a class="tweet-self-thread-button tweet-thread-right" target="_blank" href="https://twitter.com/${t.in_reply_to_screen_name}/status/${t.in_reply_to_status_id_str}">${LOC.show_this_thread.message}</a>` : ``}
                 </div>
-                <div class="tweet-reply" hidden>
+                <div class="tweet-edit-section tweet-reply" hidden>
                     <br>
                     <b style="font-size: 12px;display: block;margin-bottom: 5px;">${LOC.replying_to_tweet.message} <span ${!vars.disableHotkeys ? 'title="ALT+M"' : ''} class="tweet-reply-upload">${LOC.upload_media_btn.message}</span> <span class="tweet-reply-add-emoji">${LOC.emoji_btn.message}</span> <span ${!vars.disableHotkeys ? 'title="ALT+R"' : ''} class="tweet-reply-cancel">${LOC.cancel_btn.message}</span></b>
                     <span class="tweet-reply-error" style="color:red"></span>
@@ -2006,7 +2027,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
                     <span class="tweet-reply-char">${localStorage.OTisBlueVerified ? '0/25000' : '0/280'}</span><br>
                     <div class="tweet-reply-media" style="padding-bottom: 10px;"></div>
                 </div>
-                <div class="tweet-quote" hidden>
+                <div class="tweet-edit-section tweet-quote" hidden>
                     <br>
                     <b style="font-size: 12px;display: block;margin-bottom: 5px;">${LOC.quote_tweet.message} <span ${!vars.disableHotkeys ? 'title="ALT+M"' : ''} class="tweet-quote-upload">${LOC.upload_media_btn.message}</span> <span class="tweet-quote-add-emoji">${LOC.emoji_btn.message}</span> <span ${!vars.disableHotkeys ? 'title="ALT+Q"' : ''} class="tweet-quote-cancel">${LOC.cancel_btn.message}</span></b>
                     <span class="tweet-quote-error" style="color:red"></span>

--- a/scripts/tweetviewer.js
+++ b/scripts/tweetviewer.js
@@ -819,7 +819,7 @@ class TweetViewer {
                 if(selection.toString().length > 0 && selection.focusNode && selection.focusNode.closest(`div.tweet[data-tweet-id="${t.id_str}"]`)) {
                     return;
                 }
-                if (!isChildOfClass(e.target, "tweet-button") && !isChildOfClass(e.target, "tweet-edit-section") && !isChildOfClass(e.target, "dropdown-menu") && !isChildOfClass(e.target, "tweet-media-element") && !isChildOfTag(e.target, "A") && !isChildOfTag(e.target, "BUTTON")) {
+                if (!e.target.closest(".tweet-button") && !e.target.closest(".tweet-edit-section") && !e.target.closest(".dropdown-menu") && !e.target.closest(".tweet-media-element") && !e.target.closest("a") && !e.target.closest("button")) {
                     this.savePageData();
                     history.pushState({}, null, `https://twitter.com/${t.user.screen_name}/status/${t.id_str}`);
                     this.updateSubpage();
@@ -846,7 +846,7 @@ class TweetViewer {
             tweet.addEventListener('mousedown', e => {
                 if(e.button === 1) {
                     // tweet-media-element is clickable, since it should open the tweet in a new tab.
-                    if(!isChildOfClass(e.target, "tweet-button") && !isChildOfClass(e.target, "tweet-edit-section") && !isChildOfClass(e.target, "dropdown-menu") && !isChildOfTag(e.target, "A") && !isChildOfTag(e.target, "BUTTON")) {
+                    if(!e.target.closest(".tweet-button") && !e.target.closest(".tweet-edit-section") && !e.target.closest(".dropdown-menu") && !e.target.closest("a") && !e.target.closest("button")) {
                         e.preventDefault();
                         openInNewTab(`https://twitter.com/${t.user.screen_name}/status/${t.id_str}`);
                     }

--- a/scripts/tweetviewer.js
+++ b/scripts/tweetviewer.js
@@ -819,7 +819,7 @@ class TweetViewer {
                 if(selection.toString().length > 0 && selection.focusNode && selection.focusNode.closest(`div.tweet[data-tweet-id="${t.id_str}"]`)) {
                     return;
                 }
-                if(e.target.classList.contains('tweet-view') || e.target.classList.contains('tweet-body') || e.target.className === 'tweet-interact') {
+                if (!isChildOfClass(e.target, "tweet-button") && !isChildOfClass(e.target, "tweet-edit-section") && !isChildOfClass(e.target, "dropdown-menu") && !isChildOfClass(e.target, "tweet-media-element") && !isChildOfTag(e.target, "A") && !isChildOfTag(e.target, "BUTTON")) {
                     this.savePageData();
                     history.pushState({}, null, `https://twitter.com/${t.user.screen_name}/status/${t.id_str}`);
                     this.updateSubpage();
@@ -845,8 +845,9 @@ class TweetViewer {
             });
             tweet.addEventListener('mousedown', e => {
                 if(e.button === 1) {
-                    e.preventDefault();
-                    if(e.target.classList.contains('tweet-view') || e.target.classList.contains('tweet-body') || e.target.className === 'tweet-interact') {
+                    // tweet-media-element is clickable, since it should open the tweet in a new tab.
+                    if(!isChildOfClass(e.target, "tweet-button") && !isChildOfClass(e.target, "tweet-edit-section") && !isChildOfClass(e.target, "dropdown-menu") && !isChildOfTag(e.target, "A") && !isChildOfTag(e.target, "BUTTON")) {
+                        e.preventDefault();
                         openInNewTab(`https://twitter.com/${t.user.screen_name}/status/${t.id_str}`);
                     }
                 }
@@ -979,7 +980,7 @@ class TweetViewer {
                 </div>
                 ${!isMatchingLanguage ? /*html*/`
                 <br>
-                <span class="tweet-translate">${LOC.view_translation.message}</span>
+                <span class="tweet-button tweet-translate">${LOC.view_translation.message}</span>
                 ` : ``}
                 ${t.extended_entities && t.extended_entities.media ? /*html*/`
                     <div class="tweet-media">
@@ -1025,7 +1026,7 @@ class TweetViewer {
                     </div>
                     ` : ''}
                     ${!isQuoteMatchingLanguage ? /*html*/`
-                    <span class="tweet-quote-translate">${LOC.view_translation.message}</span>
+                    <span class="tweet-button tweet-quote-translate">${LOC.view_translation.message}</span>
                     ` : ``}
                 </a>
                 ` : ``}
@@ -1065,8 +1066,8 @@ class TweetViewer {
                 ` : ''}
                 <a ${!options.mainTweet ? 'hidden' : ''} class="tweet-date" title="${new Date(t.created_at).toLocaleString()}" href="https://twitter.com/${t.user.screen_name}/status/${t.id_str}"><br>${new Date(t.created_at).toLocaleTimeString(undefined, { hour: 'numeric', minute: 'numeric' }).toLowerCase()} - ${new Date(t.created_at).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })}  ・ ${t.source ? t.source.split('>')[1].split('<')[0] : 'Unknown'}</a>
                 <div class="tweet-interact">
-                    <span class="tweet-interact-reply" title="${LOC.reply_btn.message}${!vars.disableHotkeys ? ' (R)' : ''}" data-val="${t.reply_count}">${options.mainTweet ? '' : formatLargeNumber(t.reply_count).replace(/\s/g, ',')}</span>
-                    <span title="${LOC.retweet_btn.message}" class="tweet-interact-retweet${t.retweeted ? ' tweet-interact-retweeted' : ''}${(t.user.protected || t.limited_actions === 'limit_trusted_friends_tweet') && t.user.id_str !== user.id_str ? ' tweet-interact-retweet-disabled' : ''}" data-val="${t.retweet_count}">${options.mainTweet ? '' : formatLargeNumber(t.retweet_count).replace(/\s/g, ',')}</span>
+                    <span class="tweet-button tweet-interact-reply" title="${LOC.reply_btn.message}${!vars.disableHotkeys ? ' (R)' : ''}" data-val="${t.reply_count}">${options.mainTweet ? '' : formatLargeNumber(t.reply_count).replace(/\s/g, ',')}</span>
+                    <span title="${LOC.retweet_btn.message}" class="tweet-button tweet-interact-retweet${t.retweeted ? ' tweet-interact-retweeted' : ''}${(t.user.protected || t.limited_actions === 'limit_trusted_friends_tweet') && t.user.id_str !== user.id_str ? ' tweet-interact-retweet-disabled' : ''}" data-val="${t.retweet_count}">${options.mainTweet ? '' : formatLargeNumber(t.retweet_count).replace(/\s/g, ',')}</span>
                     <div class="tweet-interact-retweet-menu dropdown-menu" hidden>
                         <span class="tweet-interact-retweet-menu-retweet">${t.retweeted ? LOC.unretweet.message : LOC.retweet.message}</span>
                         <span class="tweet-interact-retweet-menu-quote">${LOC.quote_tweet.message}</span>
@@ -1075,12 +1076,12 @@ class TweetViewer {
                             <span class="tweet-interact-retweet-menu-retweeters">${LOC.see_retweeters.message}</span>
                         ` : ''}
                     </div>
-                    <span title="${vars.heartsNotStars ? LOC.like_btn.message : LOC.favorite_btn.message}${!vars.disableHotkeys ? ' (L)' : ''}" class="tweet-interact-favorite ${t.favorited ? 'tweet-interact-favorited' : ''}" data-val="${t.favorite_count}">${options.mainTweet ? '' : formatLargeNumber(t.favorite_count).replace(/\s/g, ',')}</span>
+                    <span title="${vars.heartsNotStars ? LOC.like_btn.message : LOC.favorite_btn.message}${!vars.disableHotkeys ? ' (L)' : ''}" class="tweet-button tweet-interact-favorite ${t.favorited ? 'tweet-interact-favorited' : ''}" data-val="${t.favorite_count}">${options.mainTweet ? '' : formatLargeNumber(t.favorite_count).replace(/\s/g, ',')}</span>
                     ${(vars.showBookmarkCount || options.mainTweet) && typeof t.bookmark_count !== 'undefined' ? 
                         /*html*/`<span title="${LOC.bookmarks_count.message}" class="tweet-interact-bookmark${t.bookmarked ? ' tweet-interact-bookmarked' : ''}" data-val="${t.bookmark_count}">${formatLargeNumber(t.bookmark_count).replace(/\s/g, ',')}</span>` :
                     ''}
                     ${vars.seeTweetViews && t.ext && t.ext.views && t.ext.views.r && t.ext.views.r.ok && t.ext.views.r.ok.count ? /*html*/`<span title="${LOC.views_count.message}" class="tweet-interact-views" data-val="${t.ext.views.r.ok.count}">${formatLargeNumber(t.ext.views.r.ok.count).replace(/\s/g, ',')}</span>` : ''}
-                    <span class="tweet-interact-more"></span>
+                    <span class="tweet-button tweet-interact-more"></span>
                     <div class="tweet-interact-more-menu dropdown-menu" hidden>
                         ${innerWidth < 590 ? /*html*/`
                         <span class="tweet-interact-more-menu-separate">${LOC.separate_text.message}</span>
@@ -1125,7 +1126,7 @@ class TweetViewer {
                         ` : ''}
                     </div>
                 </div>
-                <div class="tweet-reply" hidden>
+                <div class="tweet-edit-section tweet-reply" hidden>
                     <br>
                     <b style="font-size: 12px;display: block;margin-bottom: 5px;">${LOC.replying_to_tweet.message} <span ${!vars.disableHotkeys ? 'title="ALT+M"' : ''} class="tweet-reply-upload">${LOC.upload_media_btn.message}</span> <span class="tweet-reply-add-emoji">${LOC.emoji_btn.message}</span> <span ${!vars.disableHotkeys ? 'title="ALT+R"' : ''} class="tweet-reply-cancel">${LOC.cancel_btn.message}</span></b>
                     <span class="tweet-reply-error" style="color:red"></span>
@@ -1134,7 +1135,7 @@ class TweetViewer {
                     <span class="tweet-reply-char">${localStorage.OTisBlueVerified ? '0/25000' : '0/280'}</span><br>
                     <div class="tweet-reply-media" style="padding-bottom: 10px;"></div>
                 </div>
-                <div class="tweet-quote" hidden>
+                <div class="tweet-edit-section tweet-quote" hidden>
                     <br>
                     <b style="font-size: 12px;display: block;margin-bottom: 5px;">${LOC.quote_tweet.message} <span ${!vars.disableHotkeys ? 'title="ALT+M"' : ''} class="tweet-quote-upload">${LOC.upload_media_btn.message}</span> <span class="tweet-quote-add-emoji">${LOC.emoji_btn.message}</span> <span ${!vars.disableHotkeys ? 'title="ALT+Q"' : ''} class="tweet-quote-cancel">${LOC.cancel_btn.message}</span></b>
                     <span class="tweet-quote-error" style="color:red"></span>


### PR DESCRIPTION
There were some issues with tweet click event handling previously, so I fixed them. For user experience, this effectively means that:
- Clicking on the text of the tweet (or other "deadzones") will now properly open that tweet.

I added two helper functions for determining relationship to a parent. Additionally, I added two extra classes:
- `tweet-button`, which denotes a button behaviour for clickable elements that should not open the tweet. This includes all of the buttons at the bottom of the tweet, as well as the translate button.
- `tweet-edit-section`, for the reply and quote editors, which should also not be interactable.

This solves issue #588.