### PR TITLE
Use text selection cursor on tweet text.

### DIFF
--- a/layouts/header/style.css
+++ b/layouts/header/style.css
@@ -786,6 +786,7 @@ input, textarea {
     word-break: break-word;
     white-space: break-spaces;
     font-family: var(--tweet-font);
+    cursor: text;
 }
 .modal-top  {
     width: 495px;


### PR DESCRIPTION
Since the intended behaviour is to make tweets not open when the cursor is over the text, I thought it would be more obvious if hovering the body text of a tweet changed the cursor to the text selection one.