### PR TITLE
fix voting on polls clicking opening tweets + NaN css width vote count percentage bug

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -530,7 +530,7 @@ function generatePoll(tweet, tweetElement, user) {
             if(user.id_str !== tweet.user.id_str && poll.selected_choice && choice.id === +poll.selected_choice.string_value) {
                 choice.selected = true;
             }
-            choice.percentage = Math.round(choice.count / voteCount * 100);
+            choice.percentage = Math.round(choice.count / voteCount * 100) || 0;
             let choiceElement = document.createElement('div');
             choiceElement.classList.add('choice');
             choiceElement.innerHTML = `
@@ -548,6 +548,7 @@ function generatePoll(tweet, tweetElement, user) {
             let choice = choices[i];
             let choiceElement = document.createElement('div');
             choiceElement.classList.add('choice', 'choice-unselected');
+            choiceElement.classList.add('tweet-button');
             choiceElement.innerHTML = `
                 <div class="choice-bg" style="width:100%"></div>
                 <div class="choice-label">${escapeHTML(choice.label)}</div>


### PR DESCRIPTION
before if you voted on a poll, due to recent changes, it'd click through the poll option and open the tweet as well
to fix that i just gave poll choices the tweet-button class

and if a poll choice had 0 votes, it's css width would be NaN, so i fixed that too by just falling back to 0 if its not a number