### PR TITLE
fix #646

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1589,6 +1589,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
                 options.top.icon = "\uf008";
                 options.top.color = isDarkModeEnabled ? "#7e5eff" : "#3300FF";
             } else {
+                options.top = null; //otherwise, undefined values in options.top
                 console.log(t.socialContext);
             }
         }


### PR DESCRIPTION
tiny oversight, if it couldn't find a viable social context type it would still pass `{}` to `appendTweet` which caused it to read `options.top.text` and `options.top.icon` as `undefined`, so now it just sets `options.top` to null in such cases