### PR TITLE
List video resolutions by the smaller resolution instead of always width

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1876,7 +1876,12 @@ async function appendTweet(t, timelineContainer, options = {}) {
                     ${videos ? /*html*/`
                         <div class="tweet-media-controls">
                             ${videos[0].ext && videos[0].ext.mediaStats && videos[0].ext.mediaStats.r && videos[0].ext.mediaStats.r.ok ? `<span class="tweet-video-views tweet-button">${Number(videos[0].ext.mediaStats.r.ok.viewCount).toLocaleString().replace(/\s/g, ',')} ${LOC.views.message}</span> • ` : ''}<span class="tweet-video-reload tweet-button">${LOC.reload.message}</span> •
-                            ${videos[0].video_info.variants.filter(v => v.bitrate).map(v => `<span class="tweet-video-quality tweet-button" data-url="${v.url}">${v.url.match(/\/(\d+)x/)[1] + 'p'}</span> `).join(" / ")}
+                            ${videos[0].video_info.variants.filter(v => v.bitrate).map(v => `<span class="tweet-video-quality tweet-button" data-url="${v.url}">${v.url.map(url => {
+                                let wh = url.match(/\/(\d+)x(\d+)/);
+                                let w = parseInt(wh[1]);
+                                let h = parseInt(wh[2]);
+                                return w < h ? w : h;
+                            }) + 'p'}</span> `).join(" / ")}
                         </div>
                     ` : ``}
                     <span class="tweet-media-data"></span>

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1876,12 +1876,12 @@ async function appendTweet(t, timelineContainer, options = {}) {
                     ${videos ? /*html*/`
                         <div class="tweet-media-controls">
                             ${videos[0].ext && videos[0].ext.mediaStats && videos[0].ext.mediaStats.r && videos[0].ext.mediaStats.r.ok ? `<span class="tweet-video-views tweet-button">${Number(videos[0].ext.mediaStats.r.ok.viewCount).toLocaleString().replace(/\s/g, ',')} ${LOC.views.message}</span> • ` : ''}<span class="tweet-video-reload tweet-button">${LOC.reload.message}</span> •
-                            ${videos[0].video_info.variants.filter(v => v.bitrate).map(v => `<span class="tweet-video-quality tweet-button" data-url="${v.url}">${v.url.map(url => {
+                            ${videos[0].video_info.variants.filter(v => v.bitrate).map(v => `<span class="tweet-video-quality tweet-button" data-url="${v.url}">${(url => {
                                 let wh = url.match(/\/(\d+)x(\d+)/);
                                 let w = parseInt(wh[1]);
                                 let h = parseInt(wh[2]);
                                 return w < h ? w : h;
-                            }) + 'p'}</span> `).join(" / ")}
+                            })(v.url) + 'p'}</span> `).join(" / ")}
                         </div>
                     ` : ``}
                     <span class="tweet-media-data"></span>

--- a/scripts/tweetviewer.js
+++ b/scripts/tweetviewer.js
@@ -1001,7 +1001,12 @@ class TweetViewer {
                     ${videos ? /*html*/`
                         <div class="tweet-media-controls">
                             ${videos[0].ext && videos[0].ext.mediaStats && videos[0].ext.mediaStats.r && videos[0].ext.mediaStats.r.ok ? `<span class="tweet-video-views">${Number(videos[0].ext.mediaStats.r.ok.viewCount).toLocaleString().replace(/\s/g, ',')} ${LOC.views.message}</span> • ` : ''}<span class="tweet-video-reload tweet-button">${LOC.reload.message}</span> •
-                            ${videos[0].video_info.variants.filter(v => v.bitrate).map(v => `<span class="tweet-video-quality tweet-button" data-url="${v.url}">${v.url.match(/\/(\d+)x/)[1] + 'p'}</span> `).join(" / ")}
+                            ${videos[0].video_info.variants.filter(v => v.bitrate).map(v => `<span class="tweet-video-quality tweet-button" data-url="${v.url}">${v.url.map(url => {
+                                let wh = url.match(/\/(\d+)x(\d+)/);
+                                let w = parseInt(wh[1]);
+                                let h = parseInt(wh[2]);
+                                return w < h ? w : h;
+                            }) + 'p'}</span> `).join(" / ")}
                         </div>
                     ` : ``}
                     <span class="tweet-media-data"></span>

--- a/scripts/tweetviewer.js
+++ b/scripts/tweetviewer.js
@@ -1001,12 +1001,12 @@ class TweetViewer {
                     ${videos ? /*html*/`
                         <div class="tweet-media-controls">
                             ${videos[0].ext && videos[0].ext.mediaStats && videos[0].ext.mediaStats.r && videos[0].ext.mediaStats.r.ok ? `<span class="tweet-video-views">${Number(videos[0].ext.mediaStats.r.ok.viewCount).toLocaleString().replace(/\s/g, ',')} ${LOC.views.message}</span> • ` : ''}<span class="tweet-video-reload tweet-button">${LOC.reload.message}</span> •
-                            ${videos[0].video_info.variants.filter(v => v.bitrate).map(v => `<span class="tweet-video-quality tweet-button" data-url="${v.url}">${v.url.map(url => {
+                            ${videos[0].video_info.variants.filter(v => v.bitrate).map(v => `<span class="tweet-video-quality tweet-button" data-url="${v.url}">${(url => {
                                 let wh = url.match(/\/(\d+)x(\d+)/);
                                 let w = parseInt(wh[1]);
                                 let h = parseInt(wh[2]);
                                 return w < h ? w : h;
-                            }) + 'p'}</span> `).join(" / ")}
+                            })(v.url) + 'p'}</span> `).join(" / ")}
                         </div>
                     ` : ``}
                     <span class="tweet-media-data"></span>


### PR DESCRIPTION
this fixes horizontal videos showing up as `1920p`, `1280p` etc, instead of `1080p`, `720p`, ...
i didnt test the changes but the changes are small enough so i dont think this should break anything, tho im worried about the regex now also matching the number after `x`, as i dont know if there might be no number there