### PR TITLE
Add unbranded release build as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For stable version:
 - Go to `about:addons`
 - Press "Install Add-on From File" and select zip file you downloaded
 
-*This reportedly works with [Firefox Extended Support Release](https://www.mozilla.org/en-US/firefox/enterprise/) and [Nightly](https://www.mozilla.org/en-US/firefox/channel/desktop/) as well.*
+*This reportedly works with [Firefox Extended Support Release](https://www.mozilla.org/en-US/firefox/enterprise/) and [Nightly](https://www.mozilla.org/en-US/firefox/channel/desktop/) as well. If you need the release version, consider the [Unbranded builds](https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds).*
 
 ## FAQ
 


### PR DESCRIPTION
Some people specifically need the release build (not beta, not delayed updates, etc), and the unbranded release builds have the ability to disable the signature requirement.