### PR TITLE
Update messages.json (fixing replacement post>tweet function in the PT-BR language)

### DIFF
--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1758,11 +1758,11 @@
 		"message": "Seguir as configurações do sistema para modo escuro"
 	},
 	"replacer_post_to_tweet": {
-		"message": "post->tweet",
+		"message": " post->tweet",
 		"description": "This string will be used to replace word 'post' with 'tweet' in various places. If, in your language, this replacement is very context-based, you can add multiple substitutions and separate them with a | (example: posts->tweet|post->tweet). On the left side of a substitution, use the word for 'post' that Twitter officially uses in your language (open notifications and you'll probably see 'someone liked your post' in your language, find that word (in this case 'post') and place it on the left side, before the '->', and then on the right side insert the translated 'tweet' word, so when replaced it'll look like 'someone liked your tweet'. The substitution terms on the left can also be regex expressions (don't insert them as '/expression/g' though, just 'expression'). For example, 'epic$' will only replace the word 'epic' if it's at the end of a sentence (because the $ character indicates the end of a string in regex). However, if, even after all these substitutions, it sounds bad in your language, you can ignore this."
 	},
 	"replacer_repost_to_retweet": {
-		"message": "repost->retweet",
+		"message": " repost->retweet",
 		"description": "If 'retweet', either the noun or the verb, is different than 'tweet' in your language, you should change this. If this replacement is very context-based in your language, you can also add multiple substitutions and separate them with a | (example: repost->retweet|ripostato->ritwittato). The substitution terms on the left can also be regex expressions (don't insert them as '/expression/g' though, just 'expression'). For example, 'epic$' will only replace the word 'epic' if it's at the end of a sentence (because the $ character indicates the end of a string in regex)."
 	},
 	"mute_user": {


### PR DESCRIPTION
Fixing replace post to tweet function to not conflict with portuguese words. Words like "reply" ("Resposta" in portuguese) contain "post" inside it and turn into ("Restweeta") which is not a word at all.

Inserted a prerequisite to have a " " before the word post for it to be replaced. But there should be a way to change the color of a word when it is replaced, because it does conflict with other words. If someone is posting something at the mail, and tweets about it, it would translate to them tweeting somethng at the mail... The function is useful but a change of color would be useful to avoid misinterpretations.

Same changes apply to replace repost>retweet