### PR TITLE
fix #850 + refine firefox client-web-legacy fix

### DIFF
--- a/scripts/background_v2.js
+++ b/scripts/background_v2.js
@@ -59,23 +59,15 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
     },
     ["blocking", "requestHeaders"]
 );
-chrome.webRequest.onBeforeSendHeaders.addListener( //this isnt particularly elegant solution but i dont want to risk doing anything that may trigger bot protection or something like that
+chrome.webRequest.onBeforeSendHeaders.addListener(
     function(details) {
         for (let i = 0; i < details.requestHeaders.length; i++) {
             if (details.requestHeaders[i].name.toLowerCase() === 'user-agent') {
                 if (details.requestHeaders[i].value.toLowerCase().includes('firefox')) {
-                    let rvRegex = /rv:(\d+\.\d+)/; //gecko version (whats important here)
-                    let versionRegex = /Firefox\/(\d+(?:\.\d+)+)/; //browser version
-                    let versionMatch = details.requestHeaders[i].value.match(versionRegex);
-                    if (versionMatch) {
-                        let version = parseFloat(versionMatch[1]);
-                        let fallback = '127.0'; //if this ever breaks maybe set this to latest firefox version
-                        if (version < 110) { //rv 110 is cutoff point between client-web-legacy and client-web, so we should just spoof browser and rv to latest
-                            details.requestHeaders[i].value = details.requestHeaders[i].value.replace(rvRegex, `rv:${fallback}`).replace(versionRegex, `Firefox/${fallback}`);
-                        } else {
-                            details.requestHeaders[i].value = details.requestHeaders[i].value.replace(rvRegex, `rv:${version}.0`);
-                        }
-                    }
+                    let fallbackVersion = '128.0'; //if this ever breaks set this to latest firefox version
+                    let rvRegex = /rv:(\d+\.\d+)/;
+                    let versionRegex = /Firefox\/(\d+(?:\.\d+)+)/;
+                    details.requestHeaders[i].value = details.requestHeaders[i].value.replace(rvRegex, `rv:${fallbackVersion}`).replace(versionRegex, `Firefox/${fallbackVersion}`); //not elegant but it works
                 }
                 break;
             }

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -3764,7 +3764,7 @@ function renderNotification(n, options = {}) {
                     document.body.appendChild(a);
                     a.click();
                     a.remove();
-                } else if(n.entry.clientEventInfo.element === "users_followed_you") {
+                } else if(n.entry.clientEventInfo.element === "users_followed_you" || n.entry.clientEventInfo.element === "follow_from_recommended_user") {
                     let a = document.createElement('a');
                     a.href = `/${user.screen_name}/followers`;
                     document.body.appendChild(a);

--- a/scripts/twchallenge.js
+++ b/scripts/twchallenge.js
@@ -63,7 +63,7 @@ window.addEventListener('message', e => {
             solveCallbacks[id].reject('Solver errored during initialization');
             delete solveCallbacks[id];
         }
-        alert(`There was an error in initializing security header generator: ${data.error}. OldTwitter doesn't allow unsigned requests anymore for your account security.`);
+        alert(`There was an error in initializing security header generator:\n${data.error}\nUser Agent: ${navigator.userAgent}\nOldTwitter doesn't allow unsigned requests anymore for your account security.`);
         console.error('Error initializing solver:');
         console.error(data.error);
     } else if(data.action === 'ready') {
@@ -163,9 +163,9 @@ async function initChallenge() {
         console.error(`Error during challenge init:`);
         console.error(e);
         if(location.hostname === 'twitter.com') {
-            alert(`There was an error in initializing security header generator: ${e}. OldTwitter doesn't allow unsigned requests anymore for your account security. Currently the main reason for this happening is social network tracker protection blocking the script. Try disabling such settings in your browser and extensions that do that and refresh the page. Also using OldTwitter from twitter.com domain is not supported.`);
+            alert(`There was an error in initializing security header generator: ${e}\nUser Agent: ${navigator.userAgent}\nOldTwitter doesn't allow unsigned requests anymore for your account security. Currently the main reason for this happening is social network tracker protection blocking the script. Try disabling such settings in your browser and extensions that do that and refresh the page. Also using OldTwitter from twitter.com domain is not supported.`);
         } else {
-            alert(`There was an error in initializing security header generator: ${e}. OldTwitter doesn't allow unsigned requests anymore for your account security. Currently the main reason for this happening is social network tracker protection blocking the script. Try disabling such settings in your browser and extensions that do that and refresh the page.`);
+            alert(`There was an error in initializing security header generator: ${e}\nUser Agent: ${navigator.userAgent}\nOldTwitter doesn't allow unsigned requests anymore for your account security. Currently the main reason for this happening is social network tracker protection blocking the script. Try disabling such settings in your browser and extensions that do that and refresh the page.`);
         }
         return false;
     }


### PR DESCRIPTION
fixes #850 (follow notifications open newtwitter) by adding support for "follow_from_recommended_user" element keyword thing

refines firefox fix
the original fix was to check if the rv was under 110, if it was then set it to 110 so that twitter wouldnt serve client-web-legacy
this worked but someone was having problems (getting served client-web-legacy somehow) and this may fix that
the new solution is also dumb-ish but probably better than the other iterations i tried
it now checks if your browser version or rv is less than the current latest version as of now, if it is then it brings it up to that version, otherwise it leaves the user agent be

adding onto that i also made it show user agent in the security header generator error so that future debugging is easier