### PR TITLE
feat: add option for profile banner transition

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -631,5 +631,6 @@
     "accepted_conversation": { "message": "Accepted conversation" },
     "anniversary_tweet": { "message": "Do you remember when you joined Twitter? I do!\n#MyTwitterAnniversary" },
     "you_shared_tweet": { "message": "You shared a tweet" },
-    "user_shared_tweet": { "message": "$NAME$ shared a tweet", "placeholders": { "name": { "content": "Display Name" } } }
+    "user_shared_tweet": { "message": "$NAME$ shared a tweet", "placeholders": { "name": { "content": "Display Name" } } },
+    "transition_profile_banner": { "message": "Use transition on profile banner" }
 }

--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -485,6 +485,7 @@ let userDataFunction = async user => {
         root.style.setProperty('--birthday-icon', '"\\f092"');
         root.style.setProperty('--joined-icon', '"\\f203"');
     }
+    console.log(vars);
     if(vars.heartsNotStars) {
         root.style.setProperty('--favorite-icon-content', '"\\f148"');
         root.style.setProperty('--favorite-icon-content-notif', '"\\f015"');

--- a/layouts/profile/style.css
+++ b/layouts/profile/style.css
@@ -772,7 +772,7 @@ body.body-old-ui .user-item-btn.follow:before {
     width: 100vw;
     object-fit: cover;
     position: relative;
-    transition: .1s;
+    transition: var(--transition-profile-banner);
     height: 5px;
     height: 500px;
 }

--- a/layouts/settings/index.html
+++ b/layouts/settings/index.html
@@ -330,7 +330,9 @@
                     <div class="setting">
                         <input type="checkbox" id="disable-profile-customizations"> <label for="disable-profile-customizations">__MSG_disable_profile_customizations__</label>
                     </div>
-
+                    <div class="setting">
+                        <input type="checkbox" id="transition-profile-banner"> <label for="transition-profile-banner">__MSG_transition_profile_banner__</label>
+                    </div>
                     <h2>__MSG_tweets_and_timeline__</h2><br>
                     <div class="setting">
                         <input type="checkbox" id="show-bookmark-count"> <label for="show-bookmark-count">__MSG_show_bookmark_count__</label>

--- a/layouts/settings/script.js
+++ b/layouts/settings/script.js
@@ -329,6 +329,7 @@ setTimeout(async () => {
     let disableAcceptType = document.getElementById('disable-accept-type');
     let showUserFollowerCountsInLists = document.getElementById('show-user-follower-counts-in-lists');
     let hideUnfollowersPage = document.getElementById('hide-unfollowers-page');
+    let transitionProfileBanner = document.getElementById('transition-profile-banner');
 
     let root = document.querySelector(":root");
     {
@@ -642,6 +643,11 @@ setTimeout(async () => {
         chrome.storage.sync.set({
             savePreferredQuality: savePreferredQuality.checked
         }, () => { });
+    });
+    transitionProfileBanner.addEventListener('change', () => {
+        chrome.storage.sync.set({
+            transitionProfileBanner: transitionProfileBanner.checked
+        }, () => { console.log('set', transitionProfileBanner.checked) });
     });
     showOriginalImages.addEventListener('change', () => {
         chrome.storage.sync.set({
@@ -1035,6 +1041,7 @@ setTimeout(async () => {
     showUserFollowerCountsInLists.checked = !!vars.showUserFollowerCountsInLists;
     showQuoteCount.checked = !!vars.showQuoteCount;
     hideUnfollowersPage.checked = !!vars.hideUnfollowersPage;
+    transitionProfileBanner.checked = !!vars.transitionProfileBanner;
     if(vars.customCSS) {
         writeCSSToDB(vars.customCSS)
     }

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -32,7 +32,7 @@ async function loadVars() {
             'acknowledgedCustomizationButton', 'modernUI', 'showExactValues', 'hideTimelineTypes', 'autotranslateLanguages', 
             'autotranslationMode', 'muteVideos', 'dontPauseVideos', 'showUserPreviewsOnMobile', 'systemDarkMode', 'localizeDigit',
             'disableRetweetHotkey', 'disableLikeHotkey', 'disableFindHotkey', 'extensionCompatibilityMode', 'disableDataSaver', 'disableAcceptType',
-            'showUserFollowerCountsInLists', 'showQuoteCount', 'hideUnfollowersPage'
+            'showUserFollowerCountsInLists', 'showQuoteCount', 'hideUnfollowersPage', 'transitionProfileBanner'
         ], data => {
             // default variables
             if(typeof(data.linkColorsInTL) !== 'boolean') {
@@ -213,6 +213,13 @@ async function loadVars() {
                 data.autotranslationMode = 'whitelist';
                 chrome.storage.sync.set({
                     autotranslationMode: 'whitelist'
+                }, () => {});
+            }
+            if(typeof(data.transitionProfileBanner) !== 'boolean') {
+                console.log('transitionProfileBanner', data.transitionProfileBanner)
+                data.transitionProfileBanner = false;
+                chrome.storage.sync.set({
+                    transitionProfileBanner: false
                 }, () => {});
             }
 

--- a/scripts/injection.js
+++ b/scripts/injection.js
@@ -533,6 +533,7 @@ let page = realPath === "" ? pages[0] : pages.find(p => (!p.exclude || !p.exclud
         isDarkModeEnabled = true;
         switchDarkMode(true);
     }
+    document.querySelector(":root").style.setProperty('--transition-profile-banner', vars.transitionProfileBanner ? '.1s' : '0s');
     if(vars.systemDarkMode) {
         var matchMediaDark = window.matchMedia('(prefers-color-scheme: dark)');
         var matchMediaLight = window.matchMedia('(prefers-color-scheme: light)');


### PR DESCRIPTION
this pr adds a way to disable the transition property on the user page for the user's banner. i honestly don't know why it was there in the first place, but i assume some people like the "delay" effect it provides, which is why this pr doesn't remove it outright. the transition is off by default, as i personally think it looks better, but it doesn't really matter whether its on or off by default so please let me know which one you'd prefer ^-^

examples below. top video is with the option on, bottom is with it off

https://github.com/user-attachments/assets/381e5cfd-a93a-4191-8443-a21a51d572ae
https://github.com/user-attachments/assets/5f5a32a1-2430-4d0b-afb6-305ca1ea673c

thanks!
