### PR TITLE
feat: scroll css variable for css theming users

### DIFF
--- a/layouts/profile/script.js
+++ b/layouts/profile/script.js
@@ -1905,6 +1905,7 @@ setTimeout(async () => {
         
         // banner scroll
         banner.style.top = `${5+Math.min(window.scrollY/4, 470/4)}px`;
+        document.querySelector(":root").style.setProperty("--scroll", `${window.scrollY}px`);
     
         // load more stuff
         if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 1000) {


### PR DESCRIPTION
this pr adds a `--scroll` css variable so that users of custom css can add scroll animations (like the banner parallax), as there's no native css api for this (afaik). i'm honestly not sure if this is \*too\* much customization, let me know what you think :)