### PR TITLE
Preserve target=_blank attribute when purifying (fix #793)

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -384,7 +384,8 @@ function escapeHTML(unsafe) {
     if(typeof unsafe === 'undefined' || unsafe === null) {
         return '';
     }
-    return DOMPurify.sanitize(String(unsafe));
+
+    return DOMPurify.sanitize(String(unsafe), { ADD_ATTR: ['target'] });
 }
 
 function html(strings, ...values) {


### PR DESCRIPTION
DOMPurify removes the `target` attribute from links

This patch copies `target` to a dummy `data-` attribute, then sets it back

`target="_blank"` gets set here: https://github.com/dimdenGD/OldTwitter/blob/7b45404380f4b83fbdfa1cfb4986156ee333aade/scripts/helpers.js#L475

But then gets removed when purifying
Fixes #793