### PR TITLE
fix: link colours not showing in timeline

### DIFF
--- a/layouts/home/style.css
+++ b/layouts/home/style.css
@@ -147,7 +147,8 @@ body {
     border-top: 1px solid var(--border);
     cursor: pointer;
     min-height: 75px;
-    padding: 10px
+    padding: 10px;
+    --link-color: var(--almost-black);
 }
 .tweet:focus {
     outline: none;
@@ -181,7 +182,6 @@ body {
 
 .tweet-header-name,
 .tweet-header-name-quote {
-    color: var(--almost-black);
     display: inline;
     font-size: 14px;
     font-weight: 700
@@ -191,7 +191,8 @@ body {
 .tweet-time,
 .tweet-header-handle-quote,
 .tweet-time-quote {
-    color: var(--light-gray);
+    color: var(--link-color);
+    opacity: 0.75;
     direction: ltr;
     display: inline;
     font-size: 13px;


### PR DESCRIPTION
according to rotes, a regression has existed for a few years where link colours weren't showing in the home timeline the vast majority of the time. this pr fully fixes this issue :3

preview is below. the top user has a link colour defined, the bottom one doesn't.
![image](https://github.com/user-attachments/assets/4afaaf52-4833-4265-9e15-8ad04bcec916)
