### PR TITLE
Shift retweet menu upwards

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -2928,6 +2928,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
             }
             if (tweetInteractRetweetMenu.hidden) {
                 tweetInteractRetweetMenu.hidden = false;
+				tweetInteractRetweetMenu.style.marginTop = "-35px";
             }
             if(retweetClicked) return;
             retweetClicked = true;


### PR DESCRIPTION
Moves the retweet button slightly up to match new Twitter's behavior (so double-clicking the RT button retweets)