### PR TITLE
fix: link colours in timeline not showing

### DIFF
--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -2866,9 +2866,11 @@ let userDataFunction = async user => {
                     }
                 }
                 const tlUsers = data.list.filter(i => i.type === 'tweet').map(i => i.user.id_str);
-                let linkData = await getLinkColors(tlUsers);
-                if(linkData) for(let i in linkData) {
-                    linkColors[linkData[i].id] = linkData[i].color;
+                if (typeof linkColors !== "undefined") {
+                    let linkData = await getLinkColors(tlUsers);
+                    if(linkData) for(let i in linkData) {
+                        linkColors[linkData[i].id] = linkData[i].color;
+                    }
                 }
                 if(options.mode === 'append' || options.mode === 'rewrite') {
                     cursorBottom = data.cursorBottom;

--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -2865,6 +2865,11 @@ let userDataFunction = async user => {
                         return;
                     }
                 }
+                const tlUsers = data.list.filter(i => i.type === 'tweet').map(i => i.user.id_str);
+                let linkData = await getLinkColors(tlUsers);
+                if(linkData) for(let i in linkData) {
+                    linkColors[linkData[i].id] = linkData[i].color;
+                }
                 if(options.mode === 'append' || options.mode === 'rewrite') {
                     cursorBottom = data.cursorBottom;
                 }

--- a/layouts/header/style.css
+++ b/layouts/header/style.css
@@ -1320,7 +1320,6 @@ span.tweet-body-text {
 }
 
 .tweet-body-main {
-    display: block !important;
     margin-top: 10px
 }
 

--- a/layouts/home/script.js
+++ b/layouts/home/script.js
@@ -395,7 +395,7 @@ setTimeout(async () => {
     // On scroll to end of timeline, load more tweets
     let loadingNewTweets = false;
     document.addEventListener('scroll', async () => {
-        if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 1000) {
+        if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 5000) {
             if (loadingNewTweets || timeline.data.length === 0) return;
             document.getElementById('load-more').click();
         }

--- a/layouts/home/script.js
+++ b/layouts/home/script.js
@@ -195,7 +195,6 @@ async function updateTimeline(mode = 'rewrite') {
     if(vars.linkColorsInTL) {
         let tlUsers = tl.map(t => t.user.id_str).filter(u => !linkColors[u]);
         let linkData = await getLinkColors(tlUsers);
-        console.log(linkData)
         if(linkData) for(let i in linkData) {
             linkColors[linkData[i].id] = linkData[i].color;
         }
@@ -297,7 +296,6 @@ async function renderTimeline(options = {}) {
     if(vars.linkColorsInTL) {
         let tlUsers = data.map(t => t.user.id_str).filter(u => !linkColors[u]);
         let linkData = await getLinkColors(tlUsers);
-        console.log(linkData)
         if(linkData) for(let i in linkData) {
             linkColors[linkData[i].id] = linkData[i].color;
         }
@@ -398,7 +396,6 @@ setTimeout(async () => {
         if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 5000 && window.scrollY > 20) {
             if (loadingNewTweets || timeline.data.length === 0) return;
             document.getElementById('load-more').click();
-            console.log("Loading more tweets...");
         }
     }, { passive: true });
 

--- a/layouts/home/script.js
+++ b/layouts/home/script.js
@@ -195,6 +195,7 @@ async function updateTimeline(mode = 'rewrite') {
     if(vars.linkColorsInTL) {
         let tlUsers = tl.map(t => t.user.id_str).filter(u => !linkColors[u]);
         let linkData = await getLinkColors(tlUsers);
+        console.log(linkData)
         if(linkData) for(let i in linkData) {
             linkColors[linkData[i].id] = linkData[i].color;
         }

--- a/layouts/home/script.js
+++ b/layouts/home/script.js
@@ -395,9 +395,10 @@ setTimeout(async () => {
     // On scroll to end of timeline, load more tweets
     let loadingNewTweets = false;
     document.addEventListener('scroll', async () => {
-        if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 5000) {
+        if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 5000 && window.scrollY > 20) {
             if (loadingNewTweets || timeline.data.length === 0) return;
             document.getElementById('load-more').click();
+            console.log("Loading more tweets...");
         }
     }, { passive: true });
 

--- a/layouts/home/script.js
+++ b/layouts/home/script.js
@@ -293,7 +293,15 @@ async function renderTimeline(options = {}) {
         } else timelineContainer.innerHTML = '';
     }
     let data = options.data;
-    console.log(data.filter(d => !!d.user.profile_link_color))
+    
+    if(vars.linkColorsInTL) {
+        let tlUsers = data.map(t => t.user.id_str).filter(u => !linkColors[u]);
+        let linkData = await getLinkColors(tlUsers);
+        console.log(linkData)
+        if(linkData) for(let i in linkData) {
+            linkColors[linkData[i].id] = linkData[i].color;
+        }
+    }
     let toRender = [];
     for(let i in data) {
         let t = data[i];

--- a/layouts/home/script.js
+++ b/layouts/home/script.js
@@ -292,7 +292,7 @@ async function renderTimeline(options = {}) {
         } else timelineContainer.innerHTML = '';
     }
     let data = options.data;
-
+    console.log(data.filter(d => !!d.user.profile_link_color))
     let toRender = [];
     for(let i in data) {
         let t = data[i];

--- a/layouts/home/style.css
+++ b/layouts/home/style.css
@@ -148,8 +148,21 @@ body {
     cursor: pointer;
     min-height: 75px;
     padding: 10px;
-    --link-color: var(--almost-black);
 }
+
+.tweet:not(.colour) .tweet-header *, .tweet:not(.colour) .tweet-time {
+    --link-color: var(--almost-black) !important;
+}
+
+.tweet-header-name-quote, .tweet-header-info-quote *, .tweet-time-quote {
+    --link-color: var(--almost-black) !important;
+    color: var(--almost-black) !important;
+}
+
+.tweet-header-info.wtf-user-link * {
+    color: var(--almost-black) !important;
+}
+
 .tweet:focus {
     outline: none;
 }

--- a/layouts/home/style.css
+++ b/layouts/home/style.css
@@ -150,7 +150,7 @@ body {
     padding: 10px;
 }
 
-.tweet:not(.colour) .tweet-header *, .tweet:not(.colour) .tweet-time {
+.tweet:not(.colour) .tweet-header *:not(.nice-button), .tweet:not(.colour) .tweet-time {
     --link-color: var(--almost-black) !important;
 }
 

--- a/layouts/tweet/style.css
+++ b/layouts/tweet/style.css
@@ -826,7 +826,6 @@ a:hover,
 }
 
 .tweet-body-main {
-    display: block !important;
     margin-top: 10px
 }
 

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1116,13 +1116,16 @@ const getLinkColors = async ids => {
             });
         })
     ]);
-    // prioritize colours in the first array
-    let linkColors = {};
-    for(let c of colours[1]) {
-        linkColors[c.id] = c.color;
+    // we need to return { id: string, color: string }[]
+    // clear duplicates; if there's two ids, prioritize the one in the first array
+    let linkColors = [];
+    for(let colour of colours[0]) {
+        linkColors.push(colour);
     }
-    for(let c of colours[0]) {
-        linkColors[c.id] = c.color;
+    for(let colour of colours[1]) {
+        if(!linkColors.find(c => c.id === colour.id)) {
+            linkColors.push(colour);
+        }
     }
     return linkColors;
 }

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1089,21 +1089,20 @@ const getLinkColors = async ids => {
         new Promise(async (resolve, reject) => {
             // firstly, get "legacyLinkColors" from storage
             chrome.storage.local.get(["legacyLinkColors"], async data => {
-                console.log(data);
                 let legacyLinkColors = data.legacyLinkColors || {};
                 // each id will either have a hex colour or -1 if the user doesn't have a custom link colour
                 let hasColourIds = ids.filter(id => legacyLinkColors[id] && legacyLinkColors[id] !== -1);
                 let noColourIds = ids.filter(id => legacyLinkColors[id] && legacyLinkColors[id] === -1);
                 let fetched = [];
                 let toFetch = ids.filter(id => !hasColourIds.includes(id) && !noColourIds.includes(id));
-                console.log("Fetching uncached user colours:", toFetch);
                 let users = [];
-                try {
-                    users = await API.user.lookup(toFetch);
-                } catch {
-                    console.warn("User colours didn't fetch (were there any?)")
+                if (toFetch.length > 0) {
+                    try {
+                        users = await API.user.lookup(toFetch);
+                    } catch {
+                        console.warn("Legacy user colours failed to fetch!")
+                    }
                 }
-                console.log(150, users);
                 for(let user of users) {
                     if(user.profile_link_color && user.profile_link_color !== "1DA1F2") {
                         fetched.push({id: user.id_str, color: user.profile_link_color});
@@ -1117,7 +1116,6 @@ const getLinkColors = async ids => {
                     fetched.push({id, color: legacyLinkColors[id]});
                 }
                 chrome.storage.local.set({legacyLinkColors}, () => {});
-                console.log("Fetched user colours:", fetched);
                 resolve(fetched);
             });
         })

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -1097,7 +1097,13 @@ const getLinkColors = async ids => {
                 let fetched = [];
                 let toFetch = ids.filter(id => !hasColourIds.includes(id) && !noColourIds.includes(id));
                 console.log("Fetching uncached user colours:", toFetch);
-                let users = await Promise.all(toFetch.map(id => API.user.get(id)));
+                let users = [];
+                try {
+                    users = await API.user.lookup(toFetch);
+                } catch {
+                    console.warn("User colours didn't fetch (were there any?)")
+                }
+                console.log(150, users);
                 for(let user of users) {
                     if(user.profile_link_color && user.profile_link_color !== "1DA1F2") {
                         fetched.push({id: user.id_str, color: user.profile_link_color});

--- a/scripts/tweetviewer.js
+++ b/scripts/tweetviewer.js
@@ -866,10 +866,12 @@ class TweetViewer {
             if(this.linkColors[t.user.id_str]) {
                 let sc = makeSeeableColor(this.linkColors[t.user.id_str]);
                 tweet.style.setProperty('--link-color', sc);
+                tweet.classList.add('colour');
             } else {
                 if(t.user.profile_link_color && t.user.profile_link_color !== '1DA1F2') {
                     let sc = makeSeeableColor(t.user.profile_link_color);
                     tweet.style.setProperty('--link-color', sc);
+                    tweet.classList.add('colour');
                 }
             }
         }
@@ -964,6 +966,7 @@ class TweetViewer {
                 //else this is not reply but mention
             });
         }
+        console.log(t);
         tweet.innerHTML = html`
             <div class="tweet-top" hidden></div>
             <a class="tweet-avatar-link" href="/${t.user.screen_name}"><img onerror="this.src = '${`${vars.useOldDefaultProfileImage ? chrome.runtime.getURL(`images/default_profile_images/default_profile_bigger.png`) : 'https://abs.twimg.com/sticky/default_profile_images/default_profile_bigger.png'}`}'" src="${`${(t.user.default_profile_image && vars.useOldDefaultProfileImage) ? chrome.runtime.getURL(`images/default_profile_images/default_profile_${Number(t.user.id_str) % 7}_normal.png`): t.user.profile_image_url_https}`.replace("_normal.", "_bigger.")}" alt="${t.user.name}" class="tweet-avatar" width="48" height="48"></a>


### PR DESCRIPTION
this PR adds back support for legacy link colours by fetching profile data on the timeline **and caching it** in order to prevent rate limits. once a user has appeared on the timeline once, their colour (or lack thereof) is stored forever, and an XHR call will not be performed for them ever again. this works because you can't change your legacy link colour anymore.

it also increases the scroll height from the bottom required to trigger new tweets to appear. this change was done in order to mask the newfound latency in fetching user data and asynchronous extension storage reads, and fixes a bug where colours weren't fetched when the "Load more" button is clicked.