### PR TITLE
fix tweets with proposed community notes not loading

### DIFF
--- a/scripts/tweetviewer.js
+++ b/scripts/tweetviewer.js
@@ -1533,7 +1533,7 @@ class TweetViewer {
         });        
 
         // community notes
-        if(t.birdwatch && options.mainTweet && !vars.hideCommunityNotes) {
+        if(t.birdwatch && t.birdwatch.subtitle && options.mainTweet && !vars.hideCommunityNotes) {
             let div = document.createElement('div');
             div.classList.add('tweet-birdwatch', 'box');
             let text = Array.from(escapeHTML(t.birdwatch.subtitle.text));


### PR DESCRIPTION
this issue only applies to people who have community notes access, doesnt actually add support for "rate proposed community notes"

simply now checks if its actually a community note and not a rate proposed notes button