### PR TITLE
fix additional url on abandoned profiles

### DIFF
--- a/layouts/profile/script.js
+++ b/layouts/profile/script.js
@@ -1775,8 +1775,8 @@ async function renderProfile() {
         let url = document.createElement('a');
         url.classList.add('profile-additional-thing', 'profile-additional-url');
         let realUrl = pageUser.entities.url.urls[0];
-        url.innerText = realUrl.display_url;
-        url.href = realUrl.expanded_url;
+        url.innerText = realUrl.display_url || realUrl.url;
+        url.href = realUrl.expanded_url || realUrl.url;
         if(!url.href.startsWith('/')) url.target = "_blank";
         additionalInfo.appendChild(url);
     }


### PR DESCRIPTION
[this profile](https://x.com/revtwt) would show "undefined" as the custom link because it hasn't been changed in years, and for some reason that makes it different

simply makes it work properly by using the other value that is there