### PR TITLE
add filename to possible download templates

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -640,6 +640,7 @@
     "custom_downloadtemplate_hintExtension": { "message": "<code>{extension}</code>: Downloaded tweet's file extension." },
     "custom_downloadtemplate_hintID": { "message": "<code>{id}</code>: Tweet's ID." },
     "custom_downloadtemplate_hintIndex": { "message": "<code>{index}</code>: Index for each file to download. (for posts with multiple media)" },
+    "custom_downloadtemplate_hintFilename": { "message": "<code>{filename}</code>: Original filename from pbs.twimg.com." },
     "nonexistent_user": { "message": "This account doesn't exist" },
     "nonexistent_user_desc": { "message": "Try searching for another." },
     "suspended_user": { "message": "Account suspended" },

--- a/layouts/settings/index.html
+++ b/layouts/settings/index.html
@@ -404,6 +404,7 @@
                     <br><span>__MSG_custom_downloadtemplate_hintExtension__</span>
                     <br><span>__MSG_custom_downloadtemplate_hintID__</span>
                     <br><span>__MSG_custom_downloadtemplate_hintIndex__</span>
+                    <br><span>__MSG_custom_downloadtemplate_hintFilename__</span>
                     <br><br>
                     <div class="setting">
                         <input type="text" style="width: 550px;" id="custom-download" placeholder="{user_screen_name}_{timestamp}_{id}{index}.{extension}"></input>

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -3605,7 +3605,8 @@ async function appendTweet(t, timelineContainer, options = {}) {
                                 "extension": extension,
                                 "timestamp": ts,
                                 "id": t.id_str,
-                                "index": _index
+                                "index": _index,
+                                "filename": url.pathname.substring(url.pathname.lastIndexOf('/') + 1, url.pathname.lastIndexOf('.'))
                             };
                             filename = filename_template.replace(/\{([\w]+)\}/g, (_, key) => filesave_map[key]);
                         }


### PR DESCRIPTION
Adds the feature described in #893.

<img width="552" alt="image" src="https://github.com/user-attachments/assets/682c5c57-eec5-453d-8560-3b6cab24c7b7">

Personally I like my filenames to be saved in a format that uses this parameter, e.g. `GTIpn2HacADAZiy_username.jpg`, so this PR allows for that as a possibility.

Note: I only added the string to `_locales/en/messages.json`, but it's missing from `id`, `zh_CN,` and `zh_TW` as I don't know those languages.