### PR TITLE
fix unfollowers keybind (g+u)

### DIFF
--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -3162,7 +3162,7 @@ setInterval(() => {
             } else if(keysHeld['KeyG'] && keysHeld['KeyB']) {
                 location.href = `/i/bookmarks`;
             } else if(keysHeld['KeyG'] && keysHeld['KeyU']) {
-                location.href = `/unfollows/followers`;
+                location.href = `/old/unfollows/followers`;
             }
         }
         window.addEventListener('keydown', (ev) => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3ec4bdda-673d-433f-864b-31f2c96dd375)

i figured it out
just changes keybind url from `/unfollows/followers` to `/old/unfollows/followers`