### PR TITLE
Prioritize custom CSS over modern UI CSS

### DIFF
--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -3099,10 +3099,10 @@ setInterval(() => {
     setTimeout(hideStuff, 1000); // weird issue on firefox
 
     // custom css
+    document.addEventListener('modernUI', e => switchModernUI(e.detail));
     document.addEventListener('customCSS', updateCustomCSS);
     document.addEventListener('customCSSVariables', () => switchDarkMode(isDarkModeEnabled));
     document.addEventListener('roundAvatars', e => switchRoundAvatars(e.detail));
-    document.addEventListener('modernUI', e => switchModernUI(e.detail));
 
     // hotkeys
     if(!vars.disableHotkeys) {


### PR DESCRIPTION
Fixed bug where some custom CSS elements were overwritten when modern UI was enabled