### PR TITLE
fix some window title stuff ("Sandbox" and "0")

### DIFF
--- a/layouts/notifications/script.js
+++ b/layouts/notifications/script.js
@@ -66,14 +66,16 @@ async function updateNotifications(options = { mode: 'rewrite', quiet: false }) 
                 API.notifications.markAsRead(cursorTop);
                 if(windowFocused) {
                     chrome.storage.local.remove(['unreadCount'], () => {});
-                    document.getElementById('site-icon').href = chrome.runtime.getURL(`images/logo32${vars.useNewIcon ? '_new' : ''}_notification.png`);
-                    let newTitle = document.title;
-                    if(document.title.startsWith('(')) {
-                        newTitle = document.title.split(') ')[1];
-                    }
-                    newTitle = `(${data.unreadNotifications}) ${newTitle}`;
-                    if(document.title !== newTitle) {
-                        document.title = newTitle;
+                    if (data.unreadNotifications > 0) {
+                        document.getElementById('site-icon').href = chrome.runtime.getURL(`images/logo32${vars.useNewIcon ? '_new' : ''}_notification.png`);
+                        let newTitle = document.title;
+                        if(document.title.startsWith('(')) {
+                            newTitle = document.title.split(') ')[1];
+                        }
+                        newTitle = `(${data.unreadNotifications}) ${newTitle}`;
+                        if(document.title !== newTitle) {
+                            document.title = newTitle;
+                        }
                     }
                     notificationBus.postMessage({type: 'markAsRead', cursor: cursorTop});
                 }

--- a/scripts/iframeNavigation.js
+++ b/scripts/iframeNavigation.js
@@ -34,7 +34,7 @@ if(!window.top.windows && window.top === window) {
 }
 if(!window.top.windows.includes(window)) window.top.windows.push(window);
 if(!window._realPath) window._realPath = location.pathname;
-if(window.top !== window) {
+if(window.top !== window && location.protocol == 'https:') {
     setTimeout(() => {
         window.top.document.title = document.title;
     }, 1000);


### PR DESCRIPTION
this fixes #930 and fixes the window title sometimes having "(0)" at the beginning (0 notifications)

for the "Sandbox" fix, i can't Exactly figure out what is causing it but it happens because of iframe navigation setting the window title to the solver frame's title, and this only seems to happen when "about:blank" is what the iframe navigation sees as the current `window.location` (but i still have no idea why this causes the "Sandbox" bug, i don't understand any of the code i've tread in)

for the "0" fix, i just check if unreads are more than zero before setting the cosmetic stuff