### PR TITLE
README: Add link to Manual installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This extension doesn't add any CSS on top of original Twitter. It's fully origin
 ## Installation
 
 **Chrome, Edge, Opera, Brave & Chromium browsers:** [Chrome Web Store](https://chrome.google.com/webstore/detail/old-twitter-layout-2022/jgejdcdoeeabklepnkdbglgccjpdgpmf)  
-**Firefox:** ~~[Addons For Firefox](https://addons.mozilla.org/en-US/firefox/addon/old-twitter-layout-2022/)~~ was removed, install manually from Github
+**Firefox:** ~~[Addons For Firefox](https://addons.mozilla.org/en-US/firefox/addon/old-twitter-layout-2022/)~~ was removed, [install manually from Github](#Manual-installation)
 
 ## Donate
 


### PR DESCRIPTION
was searching thru issues for more detailed instructions on how to manually install, didn't notice there was a section in the readme til much later. I linked to the top-level Manual installation section and not the Firefox sub-section to make sure no info is missed, and in case chrome users who want to manually install (for some reason) click that link. 

Thank you so much for making this addon, BTW!