### PR TITLE
fix challenge solver (fixes #1030)

### DIFF
--- a/sandbox.html
+++ b/sandbox.html
@@ -7,7 +7,7 @@
     <meta name="twitter-site-verification" content="loading" />
 </head>
 <body>
-    <div id="anims" style="display:none"></div>
+    <div id="anims"></div>
     <script>
         function sleep(ms) {
             return new Promise(resolve => setTimeout(resolve, ms));

--- a/scripts/twchallenge.js
+++ b/scripts/twchallenge.js
@@ -14,7 +14,14 @@ let sandboxUrl = fetch(chrome.runtime.getURL(`sandbox.html`))
 function createSolverFrame() {
     if (solverIframe) solverIframe.remove();
     solverIframe = document.createElement('iframe');
-    solverIframe.style.display = 'none';
+    //display:none causes animations to not play which breaks the challenge solver, so have to hide it in different way
+    solverIframe.style.position = 'absolute';
+    solverIframe.width = '0px';
+    solverIframe.height = '0px';
+    solverIframe.style.border = 'none';
+    solverIframe.style.opacity = 0;
+    solverIframe.style.pointerEvents = 'none';
+    solverIframe.tabIndex = -1;
     sandboxUrl.then(url => solverIframe.src = url);
     let injectedBody = document.getElementById('injected-body');
     if(injectedBody) {


### PR DESCRIPTION
the solver frame being set to display:none meant that animations couldn't play, meaning the animation part of generating x-client-transaction-id was always invalid ever since this was added

this also fixes #1030, which involves an endpoint that recently started requiring valid challenges