### PR TITLE
fix: add text overflow ellipsis to notification text

### DIFF
--- a/layouts/header/style.css
+++ b/layouts/header/style.css
@@ -2404,6 +2404,8 @@ rt.furigana {
     position: relative;
     width: 475px;
     font-family: var(--tweet-font);
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .notification-avatars {


### PR DESCRIPTION
Hello!
Today I received a notification that has a single word that overflows the notification component, so I added the overflow CSS to notification-text, adding an ellipsis when a single word is bigger than the notification width