### PR TITLE
Do not escape HTML for usernames

### DIFF
--- a/scripts/tweetConstructor.js
+++ b/scripts/tweetConstructor.js
@@ -245,7 +245,7 @@ async function constructQuotedTweet(
                 {
                     className: userNameClass,
                 },
-                [escapeHTML(t.quoted_status.user.name)]
+                [t.quoted_status.user.name]
             ),
             " ",
             // At handle
@@ -524,7 +524,7 @@ async function constructTweet(t, tweetConstructorArgs, options = {}) {
                             : "",
                     className: tweetHeaderClass,
                 },
-                [escapeHTML(t.user.name)]
+                [t.user.name]
             ),
             " ",
             // @Handle


### PR DESCRIPTION
Fixes display names with quotes in the title. This should be safe as string values  in `tdeb.js` uses `createTextNode()` which is safe from XSS.

There's no need to change for `screen_name`.