### PR TITLE
Prevent rate limit when performing bulk follower lookup for filter

### DIFF
--- a/layouts/profile/script.js
+++ b/layouts/profile/script.js
@@ -916,6 +916,9 @@ async function renderFollowers(clear = true, cursor) {
                                     }
                                 }) : ''
                             ])));
+                            if(i >= userIds.length) {
+                                break;
+                            }
                             let seconds = 60;
                             loadingSortedFollowers.innerText = loadingSortedFollowers.innerText + ` (${seconds}s)`;
                             let interval = setInterval(() => {

--- a/layouts/profile/script.js
+++ b/layouts/profile/script.js
@@ -858,24 +858,20 @@ async function renderFollowers(clear = true, cursor) {
                     if(sortedFollowers[user.id_str].followers.length === 0 || Date.now() - sortedFollowers[user.id_str].lastUpdate > 60000 * 60 * 24) {
                         let i = 0;
                         while(i < userIds.length) {
-                            let users1, users2, users3, users4, users5, users6, users7;
+                            let users1, users2, users3, users4, users5;
                             try {
                                 [
                                     users1,
                                     users2,
                                     users3,
                                     users4,
-                                    users5,
-                                    users6,
-                                    users7
+                                    users5
                                 ] = await Promise.all([
                                     API.user.lookup(userIds.slice(i, i+100)),
                                     i + 100 < userIds.length ? API.user.lookup(userIds.slice(i+100, i+200)) : [],
                                     i + 200 < userIds.length ? API.user.lookup(userIds.slice(i+200, i+300)) : [],
                                     i + 300 < userIds.length ? API.user.lookup(userIds.slice(i+300, i+400)) : [],
-                                    i + 400 < userIds.length ? API.user.lookup(userIds.slice(i+400, i+500)) : [],
-                                    i + 500 < userIds.length ? API.user.lookup(userIds.slice(i+500, i+600)) : [],
-                                    i + 600 < userIds.length ? API.user.lookup(userIds.slice(i+600, i+700)) : []
+                                    i + 400 < userIds.length ? API.user.lookup(userIds.slice(i+400, i+500)) : []
                                 ]);
                             } catch(e) {
                                 console.error(e);
@@ -883,8 +879,8 @@ async function renderFollowers(clear = true, cursor) {
                                 await sleep(1000);
                                 continue;
                             }
-                            i += 700;
-                            let users = users1.concat(users2, users3, users4, users5, users6, users7);
+                            i += 500;
+                            let users = users1.concat(users2, users3, users4, users5);
                             loadingSortedFollowers.innerText = `${LOC.loading_all_followers.message} (${i / 100} / ${Math.ceil(userIds.length / 100)})`;
                             fetchedUsers = fetchedUsers.concat(users.map(u => ([
                                 u.id_str,
@@ -920,6 +916,16 @@ async function renderFollowers(clear = true, cursor) {
                                     }
                                 }) : ''
                             ])));
+                            let seconds = 60;
+                            loadingSortedFollowers.innerText = loadingSortedFollowers.innerText + ` (${seconds}s)`;
+                            let interval = setInterval(() => {
+                                seconds--;
+                                loadingSortedFollowers.innerText = loadingSortedFollowers.innerText.replace(/\(\d+s\)/, `(${seconds}s)`);
+                                if (seconds === 0) {
+                                    clearInterval(interval);
+                                }
+                            }, 1000);
+                            await sleep(seconds * 1000);
                         }
                         sortedFollowers[user.id_str].followers = fetchedUsers;
                         sortedFollowers[user.id_str].lastUpdate = Date.now();


### PR DESCRIPTION
This PR fixes an issue on the user's own followers page when using the filter functionality, due to what looks to be a new(?) additional rate limit handler on the user lookup endpoint imposed by X when called in quick succession.

At least for me, this is easily reproducible by calling https://api.x.com/1.1/users/lookup.json?user_id=1708130407663759360 six times in quick succession (opening in a browser logged in to X and refreshing the page works fine to test this). The first 5 requests succeed, while the 6th and all requests thereafter, until backing off for some period of time, begin to return `{"errors":[{"message":"Sorry, that page does not exist","code":34}]}` instead.

I tested with multiple increments and 60 seconds seemed to be the smallest increment that doesn't eventually fail.