### PR TITLE
Replace use of `offsetHeight` with `scrollHeight`

### DIFF
--- a/layouts/bookmarks/script.js
+++ b/layouts/bookmarks/script.js
@@ -105,7 +105,7 @@ setTimeout(async () => {
     }
     document.addEventListener('scroll', async () => {
         // loading new tweets
-        if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 500 && !end) {
+        if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight - 500 && !end) {
             if (loadingNewTweets) return;
             loadingNewTweets = true;
             await renderBookmarks(bookmarkCursor);

--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -2756,7 +2756,7 @@ let userDataFunction = async user => {
 
         let tweets = Array.from(document.getElementsByClassName('tweet'));
         let scrollPoint = scrollY + innerHeight/2;
-        let newActiveTweet = tweets.find(t => scrollPoint > t.offsetTop && scrollPoint < t.offsetTop + t.offsetHeight);
+        let newActiveTweet = tweets.find(t => scrollPoint > t.offsetTop && scrollPoint < t.offsetTop + t.scrollHeight);
         if(!activeTweet || (newActiveTweet && activeTweet.dataset.tweetId !== newActiveTweet.dataset.tweetId)) {
             if(activeTweet) {
                 activeTweet.classList.remove('tweet-active');

--- a/layouts/home/script.js
+++ b/layouts/home/script.js
@@ -393,7 +393,7 @@ setTimeout(async () => {
     // On scroll to end of timeline, load more tweets
     let loadingNewTweets = false;
     document.addEventListener('scroll', async () => {
-        if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 5000 && window.scrollY > 20) {
+        if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight - 5000 && window.scrollY > 20) {
             if (loadingNewTweets || timeline.data.length === 0) return;
             document.getElementById('load-more').click();
         }
@@ -411,7 +411,7 @@ setTimeout(async () => {
             activeTweet.classList.remove('tweet-active');
         }
         let scrollPoint = scrollY + innerHeight/2;
-        activeTweet = tweets.find(t => scrollPoint > t.offsetTop && scrollPoint < t.offsetTop + t.offsetHeight);
+        activeTweet = tweets.find(t => scrollPoint > t.offsetTop && scrollPoint < t.offsetTop + t.scrollHeight);
         if(activeTweet) {
             activeTweet.classList.add('tweet-active');
         }

--- a/layouts/itl/script.js
+++ b/layouts/itl/script.js
@@ -165,7 +165,7 @@ setTimeout(async () => {
     }
     document.addEventListener('scroll', async () => {
         // loading new tweets
-        if (subpage === 'device_follow' && (window.innerHeight + window.scrollY) >= document.body.offsetHeight - 500 && !end) {
+        if (subpage === 'device_follow' && (window.innerHeight + window.scrollY) >= document.body.scrollHeight - 500 && !end) {
             if (loadingNewTweets) return;
             loadingNewTweets = true;
             await renderDeviceNotificationTimeline(tlCursor);

--- a/layouts/lists/script.js
+++ b/layouts/lists/script.js
@@ -375,7 +375,7 @@ setTimeout(async () => {
     });
     document.addEventListener('scroll', async () => {
         // loading new tweets
-        if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 500 && !end) {
+        if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight - 500 && !end) {
             if (loadingNewTweets) return;
             loadingNewTweets = true;
             await renderList();
@@ -397,7 +397,7 @@ setTimeout(async () => {
             activeTweet.classList.remove('tweet-active');
         }
         let scrollPoint = scrollY + innerHeight/2;
-        activeTweet = tweets.find(t => scrollPoint > t.offsetTop && scrollPoint < t.offsetTop + t.offsetHeight);
+        activeTweet = tweets.find(t => scrollPoint > t.offsetTop && scrollPoint < t.offsetTop + t.scrollHeight);
         if(activeTweet) {
             activeTweet.classList.add('tweet-active');
         }

--- a/layouts/profile/script.js
+++ b/layouts/profile/script.js
@@ -1934,7 +1934,7 @@ document.addEventListener('findActiveTweet', () => {
         activeTweet.classList.remove('tweet-active');
     }
     let scrollPoint = scrollY + innerHeight/2;
-    activeTweet = tweets.find(t => scrollPoint > t.offsetTop && scrollPoint < t.offsetTop + t.offsetHeight);
+    activeTweet = tweets.find(t => scrollPoint > t.offsetTop && scrollPoint < t.offsetTop + t.scrollHeight);
     if(activeTweet) {
         activeTweet.classList.add('tweet-active');
     }
@@ -2039,7 +2039,7 @@ setTimeout(async () => {
         banner.style.top = `${5+Math.min(window.scrollY/4, 470/4)}px`;
     
         // load more stuff
-        if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 1000) {
+        if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight - 1000) {
             if(subpage === 'following') {
                 if(!loadingFollowing) followingMoreBtn.click();
                 return;

--- a/layouts/search/script.js
+++ b/layouts/search/script.js
@@ -316,7 +316,7 @@ setTimeout(async () => {
     });
     document.addEventListener('scroll', async () => {
         // load more tweets
-        if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 1000) {
+        if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight - 1000) {
             if (loadingNewTweets || !cursor) return;
             loadingNewTweets = true;
             await renderSearch(cursor, true);
@@ -340,7 +340,7 @@ setTimeout(async () => {
             activeTweet.classList.remove('tweet-active');
         }
         let scrollPoint = scrollY + innerHeight/2;
-        activeTweet = tweets.find(t => scrollPoint > t.offsetTop && scrollPoint < t.offsetTop + t.offsetHeight);
+        activeTweet = tweets.find(t => scrollPoint > t.offsetTop && scrollPoint < t.offsetTop + t.scrollHeight);
         if(activeTweet) {
             activeTweet.classList.add('tweet-active');
         }

--- a/layouts/topics/script.js
+++ b/layouts/topics/script.js
@@ -104,7 +104,7 @@ setTimeout(async () => {
     }
     document.addEventListener('scroll', async () => {
         // loading new tweets
-        if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 500 && !end) {
+        if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight - 500 && !end) {
             if (loadingNewTweets) return;
             loadingNewTweets = true;
             await renderTopic(cursor);

--- a/layouts/tweet/script.js
+++ b/layouts/tweet/script.js
@@ -764,7 +764,7 @@ document.addEventListener('findActiveTweet', () => {
         activeTweet.classList.remove('tweet-active');
     }
     let scrollPoint = scrollY + innerHeight/2;
-    activeTweet = tweets.find(t => scrollPoint > t.offsetTop && scrollPoint < t.offsetTop + t.offsetHeight);
+    activeTweet = tweets.find(t => scrollPoint > t.offsetTop && scrollPoint < t.offsetTop + t.scrollHeight);
     if(activeTweet) {
         activeTweet.classList.add('tweet-active');
     }
@@ -814,7 +814,7 @@ setTimeout(async () => {
 
     document.addEventListener('scroll', async () => {
         // loading new tweets
-        if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 700) {
+        if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight - 700) {
             if (loadingNewTweets) return;
             if(cursor) {
                 loadingNewTweets = true;


### PR DESCRIPTION
This PR replaces all uses of `offsetHeight` with `scrollHeight`. The reason being is that `offsetHeight` can be affected by the `overflow-*` CSS properties, where as `scrollHeight` is not and will always return the full height of the element.

I'm unable to reproduce it consistently, but sometimes `document.body.offsetHeight` will return the height of the viewport rather than the whole height of the body, and I suspect it is related to when `overflow-y` is modified on the `body`. When it happens though, the code that uses this is often related to automatically fetching new data, thus it fetches it on every scroll event rather than actually meeting the intended condition of scrolling when near the bottom of the page. Using `scrollHeight` as this PR does prevents this issue.