### PR TITLE
fix tweeting

### DIFF
--- a/scripts/apis.js
+++ b/scripts/apis.js
@@ -4380,8 +4380,7 @@ const API = {
                     {
                         method: "POST",
                         headers: {
-                            authorization:
-                                "Bearer AAAAAAAAAAAAAAAAAAAAAPYXBAAAAAAACLXUNDekMxqa8h%2F40K4moUkGsoc%3DTYfbDKbT3jJPCEVnMYqilB28NHfOPqkca3qaAxGfsyKCs0wRbw",
+                            authorization: OLDTWITTER_CONFIG.public_token,
                             "x-csrf-token": OLDTWITTER_CONFIG.csrf,
                             "x-twitter-auth-type": "OAuth2Session",
                             "content-type": "application/json; charset=utf-8",


### PR DESCRIPTION
twitter revoked the unused authorization key for the old "Twitter Web Client", which oldtwitter used for aesthetic when tweeting. rip

fixes #1105 and #1107