### PR TITLE
fix #1113

### DIFF
--- a/scripts/apis.js
+++ b/scripts/apis.js
@@ -186,7 +186,7 @@ function parseTweet(res) {
         tweet.user.verified = true;
         tweet.user.verified_type = "Blue";
     }
-    if (tweet.retweeted_status_result) {
+    if (tweet.retweeted_status_result?.result) {
         let result = tweet.retweeted_status_result.result;
         if (
             result.limitedActionResults &&


### PR DESCRIPTION
for some reason, retweeted_status_result was {} on this [random tweet](https://twitter.com/ArknightsStaff/status/1965612945230246015), but code only checked for that and not for `result` inside of it, now it checks for both