### PR TITLE
Add absolute path leading slash to hrefs in tweet-footer

### DIFF
--- a/scripts/tweetConstructor.js
+++ b/scripts/tweetConstructor.js
@@ -939,7 +939,7 @@ async function constructTweet(t, tweetConstructorArgs, options = {}) {
             elNew(
                 "a",
                 {
-                    href: `${t.user.screen_name}/status/${t.id_str}`,
+                    href: `/${t.user.screen_name}/status/${t.id_str}`,
                     class: ["tweet-footer-stat", "tweet-footer-stat-o"],
                 },
                 [
@@ -964,7 +964,7 @@ async function constructTweet(t, tweetConstructorArgs, options = {}) {
             elNew(
                 "a",
                 {
-                    href: `${t.user.screen_name}/status/${t.id_str}/retweets`,
+                    href: `/${t.user.screen_name}/status/${t.id_str}/retweets`,
                     class: ["tweet-footer-stat", "tweet-footer-stat-o"],
                 },
                 [
@@ -993,7 +993,7 @@ async function constructTweet(t, tweetConstructorArgs, options = {}) {
                 elNew(
                     "a",
                     {
-                        href: `${t.user.screen_name}/status/${t.id_str}/retweets/with_comments`,
+                        href: `/${t.user.screen_name}/status/${t.id_str}/retweets/with_comments`,
                         class: ["tweet-footer-stat", "tweet-footer-stat-q"],
                     },
                     [
@@ -1024,7 +1024,7 @@ async function constructTweet(t, tweetConstructorArgs, options = {}) {
             elNew(
                 "a",
                 {
-                    href: `${t.user.screen_name}/status/${t.id_str}/likes`,
+                    href: `/${t.user.screen_name}/status/${t.id_str}/likes`,
                     class: ["tweet-footer-stat", "tweet-footer-stat-f"],
                 },
                 [


### PR DESCRIPTION
I haven't tested it but I believe this commit should fix the relative path issue in the tweet footer when you open a tweet in a new tab and possibly also #1111. Example:
<img width="620" height="176" alt="image" src="https://github.com/user-attachments/assets/492d59a8-681f-4ff6-ae92-b2b2ba724b9d" />
Without the leading `/`, the links lead to:
<img width="425" height="17" alt="image" src="https://github.com/user-attachments/assets/38a7cb78-66a5-4e99-9889-c0e53e260276" />
