### PR TITLE
Fix hr element in tweet menu of user's own tweet is broken

### DIFF
--- a/scripts/tweetConstructor.js
+++ b/scripts/tweetConstructor.js
@@ -1303,7 +1303,7 @@ async function constructTweet(t, tweetConstructorArgs, options = {}) {
         ),
     ];
     if (t.user.id_str === user.id_str) {
-        dropDownMoreInteractionsArray.push("hr");
+        dropDownMoreInteractionsArray.push(elNew("hr"));
         dropDownMoreInteractionsArray.push(
             elNew(
                 "span",


### PR DESCRIPTION
<img width="267" height="373" alt="image" src="https://github.com/user-attachments/assets/ca3dd1b6-3bde-49bb-9484-21f1bd9f977f" />

Fix a small bug that the hr element in tweet menu is not correctly shown, instead the text "hr" appears.