### PR TITLE
fix: adjust padding for new tweet container in mobile ui

### DIFF
--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -418,6 +418,7 @@ function hideStuff() {
         hideStyle.innerHTML += html`
             #timeline-type-center { display: none !important; }
             #timeline-type-right { display: none !important; }
+            #new-tweet-container { margin-top: 0 !important; }
         `;
     }
     if(vars.hideFollowers) {


### PR DESCRIPTION
There's an empty space in mobile UI between the header and new tweet input when timeline type switch is hidden, originating from [here](https://github.com/dimdenGD/OldTwitter/blob/1648e5f592cff3ad5012434f4b099f2417c2e963/layouts/header/style.css#L2910). This PR attempts to fix it.

<img width="500" height="557" src="https://github.com/user-attachments/assets/0cf3aa69-54e9-488d-b5e0-12179107c5c3" />
