### PR TITLE
fix: fix profile preview positioning in search dropdown (#1240)

### DIFF
--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -2576,12 +2576,27 @@ let userDataFunction = async user => {
             });
             shadow.appendChild(div);
 
-            if(isSticky(el)) {
+            if(isSticky(el) && !el.closest('#search-results')) {
                 el.after(userPreview);
             } else {
                 let rects = el.getBoundingClientRect();
-                userPreview.style.top = `${rects.top + window.scrollY+ 20}px`;
-                userPreview.style.left = `${rects.left + window.scrollX}px`;
+                let topValue;
+                
+                if (el.closest('#search-results')) {
+                    let searchInput = document.getElementById('search-input');
+                    let searchRect = searchInput.getBoundingClientRect();
+
+                    topValue = searchRect.top + window.scrollY + 40;
+
+                    userPreview.style.left = `${rects.left + window.scrollX - 320}px`;
+                    userPreview.style.zIndex = "10000";
+                } else {
+                    topValue = rects.top + window.screenY + 60;
+                    userPreview.style.left = `${rects.left + window.scrollX}px`;
+                }
+                
+                userPreview.style.top = `${topValue}px`;
+
                 let closestTweet = el.closest('.tweet');
                 if(closestTweet) {
                     let linkColor = closestTweet.style.getPropertyValue('--link-color');


### PR DESCRIPTION
Fixes #1240

What this PR does:
This PR fixes a UI bug where profile previews were breaking the layout of the search results dropdown. Previously, hovering over a user in the search list would inject the preview inside the dropdown, causing it to expand or shift other elements.

Changes:
Forced Overlay Mode: Prevented isSticky logic from triggering for search results, ensuring the preview is always appended to document.body instead of being injected as a sibling.

Fixed Positioning: Re-calculated the top and left coordinates relative to the #search-input rather than the individual list item. This ensures the preview remains at a consistent height and doesn't "jump" while scrolling/hovering through the list.

Left-Side Alignment: Positioned the preview to the left of the search dropdown to avoid overlapping with the results and to handle limited screen space on the right side.

Z-Index Correction: Increased the stacking order to ensure the preview floats above all other navbar elements.

Screenshots:

Before: 
<img width="817" height="627" alt="image" src="https://github.com/user-attachments/assets/ef46dad5-74e2-47ae-b7d9-bc6c01c79c80" />

After: 
<img width="886" height="551" alt="Screenshot 2026-04-25 134808" src="https://github.com/user-attachments/assets/c56dce02-3435-4649-b90e-403f9205542e" />
