### PR TITLE
change x chat iframe URL

### DIFF
--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -1398,7 +1398,7 @@ let userDataFunction = async user => {
             modal = createModal(html`
                 <div class="inbox" style="height: 100%;">
                     <div class="xchat" style="height: 100%;">
-                        <iframe id="xchat-iframe" src="https://x.com/i/chat?newtwitter=true&if=1" style="width: 100%; height: 100%; border: none;"></iframe>
+                        <iframe id="xchat-iframe" src="https://chat.x.com" style="width: 100%; height: 100%; border: none;"></iframe>
                     </div>
                 </div>
             `, "inbox-modal", () => {


### PR DESCRIPTION
OK I retested it and X Chat does in fact work now, when I tested earlier I was on the wrong commit. Requests also work without needing to open a new tab.

from #1214 