### PR TITLE
fix: guard constructTweet against undefined full_text

### DIFF
--- a/scripts/tweetConstructor.js
+++ b/scripts/tweetConstructor.js
@@ -669,7 +669,7 @@ async function constructTweet(t, tweetConstructorArgs, options = {}) {
     // Main text content
     const longShortClass =
         vars.noBigFont ||
-        t.full_text.length > 280 ||
+        (t.full_text?.length ?? 0) > 280 ||
         !options.bigFont ||
         (!options.mainTweet && location.pathname.includes("/status/"))
             ? "tweet-body-text-long"


### PR DESCRIPTION
Fixes #1252.

`constructTweet` reads `t.full_text.length` while computing the `longShortClass` for the body element, but the tweet object can lack a `full_text` property in some timeline contexts, which crashes with:

```
TypeError: Cannot read properties of undefined (reading 'length')
    at constructTweet (scripts/tweetConstructor.js:672:21)
    at appendTweet (scripts/helpers.js:2702:49)
    at renderTimeline (layouts/profile/script.js:1945:23)
```

Using `t.full_text?.length ?? 0` keeps the behaviour identical for normal tweets (length compared against 280) and falls back to the short-tweet branch when `full_text` is missing, preserving the existing styling instead of crashing the timeline render.