### PR TITLE
fix appendTweet issue with user_mentions

### DIFF
--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -2673,7 +2673,7 @@ async function appendTweet(t, timelineContainer, options = {}) {
             blockUserText = `${LOC.block_user.message} @${t.user.screen_name}`;
             unblockUserText = `${LOC.unblock_user.message} @${t.user.screen_name}`;
         }
-        if (t.in_reply_to_screen_name && t.display_text_range) {
+        if (t.in_reply_to_screen_name && t.display_text_range && t.entities.user_mentions) {
             t.entities.user_mentions.forEach((user_mention) => {
                 if (user_mention.indices[0] < t.display_text_range[0]) {
                     mentionedUserArray.push(
@@ -2687,7 +2687,8 @@ async function appendTweet(t, timelineContainer, options = {}) {
         if (
             t.quoted_status &&
             t.quoted_status.in_reply_to_screen_name &&
-            t.display_text_range
+            t.display_text_range &&
+            t.quoted_status.entities.user_mentions
         ) {
             t.quoted_status.entities.user_mentions.forEach((user_mention) => {
                 if (user_mention.indices[0] < t.display_text_range[0]) {

--- a/scripts/tweetviewer.js
+++ b/scripts/tweetviewer.js
@@ -1439,7 +1439,7 @@ class TweetViewer {
             blockUserText = `${LOC.block_user.message} @${t.user.screen_name}`;
             unblockUserText = `${LOC.unblock_user.message} @${t.user.screen_name}`;
         }
-        if (t.in_reply_to_screen_name && t.display_text_range) {
+        if (t.in_reply_to_screen_name && t.display_text_range && t.entities.user_mentions) {
             t.entities.user_mentions.forEach((user_mention) => {
                 if (user_mention.indices[0] < t.display_text_range[0]) {
                     mentionedUserText += `<a href="/${user_mention.screen_name}">@${user_mention.screen_name}</a> `;
@@ -1450,7 +1450,8 @@ class TweetViewer {
         if (
             t.quoted_status &&
             t.quoted_status.in_reply_to_screen_name &&
-            t.display_text_range
+            t.display_text_range &&
+            t.quoted_status.entities.user_mentions
         ) {
             t.quoted_status.entities.user_mentions.forEach((user_mention) => {
                 if (user_mention.indices[0] < t.display_text_range[0]) {


### PR DESCRIPTION
```
TypeError: Cannot read properties of undefined (reading 'forEach') at appendTweet (chrome-extension://fackcpaahngnmbepnejopehbfcohfjma/scripts/helpers.js:2677:38) at renderTimeline (chrome-extension://fackcpaahngnmbepnejopehbfcohfjma/layouts/home/script.js:336:23) at (tweet id) (OldTwitter v1.9.6.5)
```

code assumed `entities.user_mentions` would be available in some contexts which causes error in tweet parsing, new tweets seem to omit it in these cases now

fixes basically every issue opened since #1270