### PR TITLE
Fix undefined user ids in parseTweet by falling back to rest_id

### DIFF
--- a/scripts/apis.js
+++ b/scripts/apis.js
@@ -178,7 +178,8 @@ function parseTweet(res) {
     let tweet = res.legacy;
     if (!res.core) return;
     tweet.user = res.core.user_results.result.legacy;
-    tweet.user.id_str = tweet.user_id_str;
+    tweet.user.id_str =
+        tweet.user_id_str || res.core.user_results.result.rest_id;
     const ur = res.core.user_results.result;
     if(ur?.location?.location) tweet.user.location = ur.location.location;
     if(ur?.avatar?.image_url) tweet.user.profile_image_url_https = ur.avatar.image_url;
@@ -255,7 +256,8 @@ function parseTweet(res) {
                     }
                 }
                 result.legacy.quoted_status.user = qu;
-                result.legacy.quoted_status.user.id_str = qu.id_str;
+                result.legacy.quoted_status.user.id_str =
+                    qu.id_str || qur.rest_id;
                 tweetStorage[result.legacy.quoted_status.id_str] =
                     result.legacy.quoted_status;
                 tweetStorage[result.legacy.quoted_status.id_str].cacheDate =
@@ -300,7 +302,8 @@ function parseTweet(res) {
                     }
                 }
                 result.legacy.quoted_status.user = qu;
-                result.legacy.quoted_status.user.id_str = qu.id_str;
+                result.legacy.quoted_status.user.id_str =
+                    qu.id_str || qur.rest_id;
                 tweetStorage[result.legacy.quoted_status.id_str] =
                     result.legacy.quoted_status;
                 tweetStorage[result.legacy.quoted_status.id_str].cacheDate =
@@ -337,7 +340,7 @@ function parseTweet(res) {
                 }
             }
             tweet.retweeted_status.user = u;
-            tweet.retweeted_status.user.id_str = u.id_str;
+            tweet.retweeted_status.user.id_str = u.id_str || ur.rest_id;
             tweet.retweeted_status.ext = {};
             if (result.views) {
                 tweet.retweeted_status.ext.views = {
@@ -416,7 +419,7 @@ function parseTweet(res) {
                     }
                 }
                 tweet.quoted_status.user = u;
-                tweet.quoted_status.user.id_str = u.id_str;
+                tweet.quoted_status.user.id_str = u.id_str || ur.rest_id;
                 tweet.quoted_status.ext = {};
                 if (result.views) {
                     tweet.quoted_status.ext.views = {


### PR DESCRIPTION
## Summary

X no longer includes the legacy user id fields (`user_id_str` on the tweet legacy, `id_str` on the user legacy) in some GraphQL responses such as `HomeTimeline`, while `TweetDetail` still has them. `parseTweet` relied on those fields alone, so tweets parsed from the home timeline end up with `user.id_str === undefined`.

This silently breaks every action that sends the author id from the timeline — block, mute, copy user ID — and poisons the `userStorage` cache with an `undefined` key.

## Fix

Fall back to `user_results.result.rest_id` (the canonical id that is always present in GraphQL responses) in all five user id assignments in `parseTweet`: main tweet, retweeted status, quoted status, and quotes inside retweets. The legacy fields still take precedence when present, so endpoints that still send them (e.g. `TweetDetail`) are unaffected. This matches the `user.legacy.id_str = user.rest_id` pattern already used elsewhere in `apis.js`.

## Test plan

- Unit-tested `parseTweet` against fixtures with and without the legacy id fields: without them, all user ids previously came out `undefined` and now resolve to `rest_id`; with them, the legacy values still win.
- Verified on the home timeline that actions using `t.user.id_str` receive a real user id again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)