### PR TITLE
fix some users' description / profile info not being rendered 

### DIFF
--- a/layouts/header/script.js
+++ b/layouts/header/script.js
@@ -2539,7 +2539,7 @@ let userDataFunction = async user => {
             div.addEventListener('mouseleave', leaveFunction);
             let links = Array.from(div.querySelector('.preview-user-description').querySelectorAll('a'));
             links.forEach(link => {
-                let realLink = user.entities.description.urls.find(u => u.url === link.href);
+                let realLink = user.entities.description?.urls?.find(u => u.url === link.href);
                 if (realLink) {
                     link.href = realLink.expanded_url;
                     if(!link.href.startsWith('/')) link.target = '_blank';

--- a/layouts/profile/script.js
+++ b/layouts/profile/script.js
@@ -931,7 +931,7 @@ async function renderFollowers(clear = true, cursor) {
                                 u.friends_count,
                                 u.description ? u.description.replace(/https:\/\/t\.co\/[a-zA-Z0-9]+/g, m => {
                                     if(!u.entities || !u.entities.description || !u.entities.description.urls) return m;
-                                    let entity = u.entities.description.urls.find(e => e.url === m);
+                                    let entity = u.entities.description?.urls?.find(e => e.url === m);
                                     if(entity) {
                                         return entity.expanded_url;
                                     } else {
@@ -1272,7 +1272,7 @@ async function renderProfile() {
             document.getElementById('profile-bio').append(span);
             let links = Array.from(span.getElementsByTagName('a'));
             links.forEach(link => {
-                let realLink = pageUser.entities.description.urls.find(u => u.url === link.href);
+                let realLink = pageUser.entities.description?.urls?.find(u => u.url === link.href);
                 if (realLink) {
                     link.href = realLink.expanded_url;
                     if(!link.href.startsWith('/')) link.target = '_blank';
@@ -1815,7 +1815,7 @@ async function renderProfile() {
 
     let links = Array.from(document.getElementById('profile-bio').getElementsByTagName('a'));
     links.forEach(link => {
-        let realLink = pageUser.entities.description.urls.find(u => u.url === link.href);
+        let realLink = pageUser.entities.description?.urls?.find(u => u.url === link.href);
         if (realLink) {
             link.href = realLink.expanded_url;
             if(!link.href.startsWith('/')) link.target = '_blank';


### PR DESCRIPTION
users who don't have a url in their description but do have an `<a>` (like a hashtag or mention) causes oldtwitter to try to find an associated `urls` entity in `entities.description`, which doesn't exist in this case. presumably, twitter used to return `urls`(empty) even if they had none, otherwise i figure someone would've noticed this by now